### PR TITLE
Add a `computed-metadata.include` for WG21

### DIFF
--- a/bikeshed/boilerplate/wg21/computed-metadata.include
+++ b/bikeshed/boilerplate/wg21/computed-metadata.include
@@ -1,0 +1,3 @@
+{
+    "URL": "https://wg21.link/[SHORTNAME]R[LEVEL]"
+}


### PR DESCRIPTION
* Allows the URL metadata field to be omitted - if it is, the link is computed from the paper and revision number using wg21.link.