### PR TITLE
Add padding before switch icon, rebase tests

### DIFF
--- a/bikeshed/spec-data/readonly/boilerplate/stylesheet.include
+++ b/bikeshed/spec-data/readonly/boilerplate/stylesheet.include
@@ -464,7 +464,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/WICG/construct-stylesheets/index.html
+++ b/tests/github/WICG/construct-stylesheets/index.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/immersive-web/real-world-geometry/webxrmeshing-1.html
+++ b/tests/github/immersive-web/real-world-geometry/webxrmeshing-1.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/D1501R0.html
+++ b/tests/github/jfbastien/papers/source/D1501R0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/D2151r0.html
+++ b/tests/github/jfbastien/papers/source/D2151r0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/Math.signbit.html
+++ b/tests/github/jfbastien/papers/source/Math.signbit.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/N2218.html
+++ b/tests/github/jfbastien/papers/source/N2218.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/N4455.html
+++ b/tests/github/jfbastien/papers/source/N4455.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0323R10.html
+++ b/tests/github/jfbastien/papers/source/P0323R10.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0323R8.html
+++ b/tests/github/jfbastien/papers/source/P0323R8.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0323R9.html
+++ b/tests/github/jfbastien/papers/source/P0323R9.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0323r4.html
+++ b/tests/github/jfbastien/papers/source/P0323r4.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0323r5.html
+++ b/tests/github/jfbastien/papers/source/P0323r5.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0323r6.html
+++ b/tests/github/jfbastien/papers/source/P0323r6.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0418r1.html
+++ b/tests/github/jfbastien/papers/source/P0418r1.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0418r2.html
+++ b/tests/github/jfbastien/papers/source/P0418r2.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0476r0.html
+++ b/tests/github/jfbastien/papers/source/P0476r0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0476r1.html
+++ b/tests/github/jfbastien/papers/source/P0476r1.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0476r2.html
+++ b/tests/github/jfbastien/papers/source/P0476r2.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0502r0.html
+++ b/tests/github/jfbastien/papers/source/P0502r0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0528r0.html
+++ b/tests/github/jfbastien/papers/source/P0528r0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0528r1.html
+++ b/tests/github/jfbastien/papers/source/P0528r1.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0528r2.html
+++ b/tests/github/jfbastien/papers/source/P0528r2.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0690r0.html
+++ b/tests/github/jfbastien/papers/source/P0690r0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0690r1.html
+++ b/tests/github/jfbastien/papers/source/P0690r1.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0750r0.html
+++ b/tests/github/jfbastien/papers/source/P0750r0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0750r1.html
+++ b/tests/github/jfbastien/papers/source/P0750r1.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0907R4.html
+++ b/tests/github/jfbastien/papers/source/P0907R4.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0907r0.html
+++ b/tests/github/jfbastien/papers/source/P0907r0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0907r1.html
+++ b/tests/github/jfbastien/papers/source/P0907r1.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0907r2.html
+++ b/tests/github/jfbastien/papers/source/P0907r2.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0908r0.html
+++ b/tests/github/jfbastien/papers/source/P0908r0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P0995r0.html
+++ b/tests/github/jfbastien/papers/source/P0995r0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P1018r5.html
+++ b/tests/github/jfbastien/papers/source/P1018r5.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P1018r6.html
+++ b/tests/github/jfbastien/papers/source/P1018r6.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P1018r7.html
+++ b/tests/github/jfbastien/papers/source/P1018r7.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P1018r8.html
+++ b/tests/github/jfbastien/papers/source/P1018r8.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P1018r9.html
+++ b/tests/github/jfbastien/papers/source/P1018r9.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P1152R0.html
+++ b/tests/github/jfbastien/papers/source/P1152R0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P1152R1.html
+++ b/tests/github/jfbastien/papers/source/P1152R1.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P1152R2.html
+++ b/tests/github/jfbastien/papers/source/P1152R2.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P1152R3.html
+++ b/tests/github/jfbastien/papers/source/P1152R3.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P1152R4.html
+++ b/tests/github/jfbastien/papers/source/P1152R4.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P1205R0.html
+++ b/tests/github/jfbastien/papers/source/P1205R0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P1225R0.html
+++ b/tests/github/jfbastien/papers/source/P1225R0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P1482r0.html
+++ b/tests/github/jfbastien/papers/source/P1482r0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P1831R0.html
+++ b/tests/github/jfbastien/papers/source/P1831R0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P1831R1.html
+++ b/tests/github/jfbastien/papers/source/P1831R1.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P1860R0.html
+++ b/tests/github/jfbastien/papers/source/P1860R0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P2186R0.html
+++ b/tests/github/jfbastien/papers/source/P2186R0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P2186R1.html
+++ b/tests/github/jfbastien/papers/source/P2186R1.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/P2186R2.html
+++ b/tests/github/jfbastien/papers/source/P2186R2.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/bikeshed.html
+++ b/tests/github/jfbastien/papers/source/bikeshed.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/p0323r7.html
+++ b/tests/github/jfbastien/papers/source/p0323r7.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/p0528r3.html
+++ b/tests/github/jfbastien/papers/source/p0528r3.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/p0907r3.html
+++ b/tests/github/jfbastien/papers/source/p0907r3.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/p0995r1.html
+++ b/tests/github/jfbastien/papers/source/p0995r1.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/p1102r0.html
+++ b/tests/github/jfbastien/papers/source/p1102r0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/jfbastien/papers/source/p1119r0.html
+++ b/tests/github/jfbastien/papers/source/p1119r0.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/w3c/css-houdini-drafts/box-tree-api/Overview.html
+++ b/tests/github/w3c/css-houdini-drafts/box-tree-api/Overview.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/w3c/css-houdini-drafts/css-paint-api/issues-cr-2018.html
+++ b/tests/github/w3c/css-houdini-drafts/css-paint-api/issues-cr-2018.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/w3c/css-houdini-drafts/css-typed-om-2/Overview.html
+++ b/tests/github/w3c/css-houdini-drafts/css-typed-om-2/Overview.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/w3c/css-houdini-drafts/font-metrics-api/Overview.html
+++ b/tests/github/w3c/css-houdini-drafts/font-metrics-api/Overview.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/w3c/csswg-drafts/css-forms-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-forms-1/Overview.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/w3c/dpub-pagination/Overview.html
+++ b/tests/github/w3c/dpub-pagination/Overview.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/w3c/wcag-act/act-fr-reqs.html
+++ b/tests/github/w3c/wcag-act/act-fr-reqs.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/w3ctag/evergreen-web/index.html
+++ b/tests/github/w3ctag/evergreen-web/index.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;

--- a/tests/github/w3ctag/promises-guide/index.html
+++ b/tests/github/w3ctag/promises-guide/index.html
@@ -469,7 +469,7 @@
 	}
 	dl.switch > dt::before {
 	content: '\21AA';
-	padding: 0 0.5em 0 0;
+	padding: 0 0.5em 0 0.5em;
 	display: inline-block;
 	width: 1em;
 	text-align: right;


### PR DESCRIPTION
This PR is one way to fix the overlapping icons reported by #2443.

![image](https://user-images.githubusercontent.com/570125/218564762-f098c042-1915-4c6c-8948-7442c4c61d08.png)

All switch dts are indented by this extra padding.
Alternatively, we might outset the pilcrow to the left.