### PR TITLE
Add some defaults to the template

### DIFF
--- a/bikeshed/cli.py
+++ b/bikeshed/cli.py
@@ -667,7 +667,6 @@ Editor: Your Name, Your Company http://example.com/your-company, your-email@exam
 Abstract: A short description of your spec, one or two sentences.
 Complain About: accidental-2119 yes, missing-example-ids yes
 Markup Shorthands: markdown yes, css no
-Assume Explicit For: yes
 </pre>
 
 Introduction {#intro}

--- a/bikeshed/cli.py
+++ b/bikeshed/cli.py
@@ -661,9 +661,13 @@ Shortname: your-spec
 Level: 1
 Status: w3c/UD
 Group: WGNAMEORWHATEVER
+Repository: org/repo-name
 URL: http://example.com/url-this-spec-will-live-at
 Editor: Your Name, Your Company http://example.com/your-company, your-email@example.com, http://example.com/your-personal-website
 Abstract: A short description of your spec, one or two sentences.
+Complain About: accidental-2119 yes, missing-example-ids yes
+Markup Shorthands: markdown yes, css no
+Assume Explicit For: yes
 </pre>
 
 Introduction {#intro}


### PR DESCRIPTION
And the Repository: line that we now recommend.

This turns off css shorthands, which is debatable, but I figure that they're easy enough to trigger accidentally that most non-CSS specs should have them off, and it's easy enough for CSS specs to turn them back on.

`Assume Explicit For` is also debatable, but without it, I think it's too easy for specs to add new definitions that are correctly scoped, but that break unrelated references.