### PR TITLE
chore: remove guards and EOL requirements.txt deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,33 +6,31 @@
 #
 
 -i https://pypi.org/simple
-about-time==4.2.1; python_version >= '3.7' and python_version < '4'
+about-time==4.2.1
 aiofiles==23.1.0
 aiohttp==3.8.4
-aiosignal==1.3.1; python_version >= '3.7'
+aiosignal==1.3.1
 alive-progress==3.0.1
-async-timeout==4.0.2; python_version >= '3.6'
+async-timeout==4.0.2
 attrs==22.1.0
 certifi==2022.12.7
-charset-normalizer==3.0.1; python_version >= '3.6'
+charset-normalizer==3.0.1
 cssselect==1.2.0
-frozenlist==1.3.3; python_version >= '3.7'
+frozenlist==1.3.3
 grapheme==0.6.0
 html5lib==1.1
-idna==3.4; python_version >= '3.5'
+idna==3.4
 isodate==0.6.1
 json-home-client==1.1.1
 lxml==4.9.2
-multidict==6.0.4; python_version >= '3.7'
+multidict==6.0.4
 pillow==9.4.0
 pygments==2.13.0
 requests==2.28.2
 result==0.8.0
-six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 tenacity==8.2.2
-typing-extensions==4.5.0; python_version >= '3.7'
-uri-template==1.2.0; python_version >= '3.6'
-urllib3==1.26.14; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+typing-extensions==4.5.0
+uri-template==1.2.0
 webencodings==0.5.1
 widlparser==1.1.1
-yarl==1.8.2; python_version >= '3.7'
+yarl==1.8.2


### PR DESCRIPTION
- Remove guards for >= 3.x that were all or equal to the minimum version
- removed six and urllib3 that are no longer imported