### PR TITLE
Add the PATCG to the list of W3C CGs.

### DIFF
--- a/bikeshed/config/status.py
+++ b/bikeshed/config/status.py
@@ -226,6 +226,8 @@ megaGroups = {
             "immersivewebwg",
             "mediacapture",
             "mediawg",
+            "patcg",
+            "patcg-id",
             "ping",
             "pngwg",
             "privacycg",
@@ -296,6 +298,8 @@ w3cCgs = frozenset(
     [
         "fedidcg",
         "immersivewebcg",
+        "patcg",
+        "patcg-id",
         "privacycg",
         "processcg",
         "ricg",


### PR DESCRIPTION
The PATCG defines a separate space for drafts that it discusses but hasn't adopted, and to give those drafts distinct boilerplate (in https://github.com/speced/bikeshed-boilerplate/pull/43), I'm proposing a parallel patcg-id "group".
