### PR TITLE
Typo fix

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2482,7 +2482,7 @@ Namespacing a Definition {#dfn-for}
 -----------------------------------
 
 Some types of definitions are defined relative to a higher construct,
-such as values for a particularly property,
+such as values for a particular property,
 or attributes of a particular IDL interface.
 This is useful, as it means these names don't have to be globally unique,
 but that means your autolinks may have a hard time telling which name you intend to link to.


### PR DESCRIPTION
There was a typo that resulted in a correctly spelled word with incorrect grammar. This PR changes "a particularly property" to "a particular property".