### PR TITLE
update: Pass trust_env=True when creating aiohttp.ClientSession instances

### DIFF
--- a/bikeshed/update/manifest.py
+++ b/bikeshed/update/manifest.py
@@ -180,7 +180,7 @@ def updateByManifest(path: str, dryRun: bool = False, force: bool = False) -> Ma
 
 async def updateFiles(localPrefix: str, newPaths: list[str]) -> tuple[list[str], list[str]]:
     tasks = set()
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         for filePath in newPaths:
             coro = updateFile(localPrefix, filePath, session=session)
             tasks.add(coro)

--- a/bikeshed/update/updateBoilerplates.py
+++ b/bikeshed/update/updateBoilerplates.py
@@ -58,7 +58,7 @@ def pathsFromManifest(manifest: str) -> list[str]:
 
 async def updateFiles(localPrefix: str, newPaths: t.Sequence[str]) -> tuple[list[str], list[str]]:
     tasks = set()
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         for filePath in newPaths:
             coro = updateFile(localPrefix, filePath, session=session)
             tasks.add(coro)


### PR DESCRIPTION
aiohttp does not read environment variables (such as `$http_proxy`) by
default, which causes `bikeshed update` to time out when run behind a
proxy.

Explicitly pass trust_env=True to make it use proxy environment
variables in HTTP request.
