### PR TITLE
Let the patcg-id "group" use the UD status.

### DIFF
--- a/bikeshed/config/status.py
+++ b/bikeshed/config/status.py
@@ -301,7 +301,6 @@ w3cCgs = frozenset(
         "fedidcg",
         "immersivewebcg",
         "patcg",
-        "patcg-id",
         "privacycg",
         "processcg",
         "ricg",


### PR DESCRIPTION
Per https://github.com/speced/bikeshed-boilerplate/pull/43#issuecomment-1658832017, it should be possible for documents with `Group: patcg-id` to use the `UD` status, which isn't allowed for groups that are in `w3cCgs`. I think it's right to keep this "group" in `megaGroups["w3c"]`, although I'm not certain.