### PR TITLE
Allow multiple node return

### DIFF
--- a/bikeshed/InputSource.py
+++ b/bikeshed/InputSource.py
@@ -28,19 +28,27 @@ class InputContent:
         offset = 0
         for i, text in enumerate(self.rawLines, 1):
             lineNo = i + offset
-            # The early HTML parser runs before Markdown,
-            # and in some cases removes linebreaks that were present
-            # in the source. When properly invoked, it inserts
-            # a special PUA char for each of these omitted linebreaks,
-            # so I can remove them here and properly increment the
-            # line number.
+            # The early HTML parser can change how nodes print,
+            # so they occupy a different number of lines than they
+            # had in the source. Markdown parser needs to know
+            # the correct source lines, tho, so when this happens,
+            # the nodes will insert special PUA chars to indicate that.
+            # I can remove them here and properly adjust the line number.
             # Current known causes of this:
             # * line-ending -- turned into em dashes
             # * multi-line start tags
+            # * multi-line markdown code spans;
+            #     - the text loses its newlines
+            #     - the original text goes into an attribute on the start
+            #       tag now
             ilcc = constants.incrementLineCountChar
+            dlcc = constants.decrementLineCountChar
             if ilcc in text:
                 offset += text.count(ilcc)
                 text = text.replace(ilcc, "")
+            if dlcc in text:
+                offset -= text.count(dlcc)
+                text = text.replace(dlcc, "")
 
             ret.append(line.Line(lineNo, text))
 

--- a/bikeshed/constants.py
+++ b/bikeshed/constants.py
@@ -11,4 +11,5 @@ executeCode: bool = False
 macroStartChar = "\uebbb"
 macroEndChar = "\uebbc"
 incrementLineCountChar = "\uebbd"
+decrementLineCountChar = "\uebbf"
 bsComment = "<!--\uebbe-->"

--- a/bikeshed/h/parser.py
+++ b/bikeshed/h/parser.py
@@ -425,12 +425,14 @@ class Result(t.Generic[ResultT]):
 
 class Stream:
     _chars: str
+    _len: int
     _lineBreaks: list[int]
     startLine: int
     config: ParseConfig
 
     def __init__(self, chars: str, config: ParseConfig, startLine: int = 1) -> None:
         self._chars = chars
+        self._len = len(chars)
         self._lineBreaks = []
         self.startLine = startLine
         self.config = config
@@ -445,7 +447,7 @@ class Stream:
             return ""
 
     def eof(self, index: int) -> bool:
-        return index >= len(self._chars)
+        return index >= self._len
 
     def line(self, index: int) -> int:
         # Zero-based line index

--- a/bikeshed/h/parser.py
+++ b/bikeshed/h/parser.py
@@ -277,6 +277,7 @@ def initialDocumentParse(text: str, config: ParseConfig, startLine: int = 1) -> 
 def strFromNodes(nodes: t.Iterable[ParserNode], withIlcc: bool = False) -> str:
     strs = []
     ilcc = constants.incrementLineCountChar
+    dlcc = constants.decrementLineCountChar
     for node in nodes:
         if isinstance(node, Comment):
             # Serialize comments as a standardized, recognizable sequence
@@ -287,10 +288,13 @@ def strFromNodes(nodes: t.Iterable[ParserNode], withIlcc: bool = False) -> str:
             continue
         s = str(node)
         if withIlcc:
-            numLines = s.count("\n")
-            diffLineNo = node.endLine - node.line
-            if diffLineNo > numLines:
-                s += ilcc * (diffLineNo - numLines)
+            outputExtraLines = s.count("\n")
+            sourceExtraLines = node.endLine - node.line
+            diff = sourceExtraLines - outputExtraLines
+            if diff > 0:
+                s += ilcc * diff
+            elif diff < 0:
+                s += dlcc * -diff
         strs.append(s)
     return "".join(strs)
 

--- a/bikeshed/h/parser.py
+++ b/bikeshed/h/parser.py
@@ -57,9 +57,7 @@ def nodesFromHtml(data: str, config: ParseConfig, startLine: int = 1) -> t.Gener
             if text:
                 startLine = s.line(textI)
                 endLine = startLine + len(text.split("\n")) - 1
-                node = Text(startLine, endLine, text)
-                yield node
-                lastNode = node
+                yield Text(startLine, endLine, text)
                 text = ""
             if isinstance(node, list):
                 yield from t.cast("list[ParserNode]", node)

--- a/bikeshed/h/parser.py
+++ b/bikeshed/h/parser.py
@@ -1234,7 +1234,7 @@ def parseCodeSpan(s: Stream, start: int) -> Result[list[ParserNode]]:
     content = Text(
         line=s.line(contentStart),
         endLine=s.line(contentEnd - 1),
-        text=text,
+        text=escapeHTML(text),
     )
     endTag = EndTag(
         line=s.line(contentEnd),

--- a/bikeshed/h/parser.py
+++ b/bikeshed/h/parser.py
@@ -548,7 +548,7 @@ class Text(ParserNode):
         return self.text
 
     def curlifyApostrophes(self, lastNode: ParserNode | None) -> Text:
-        if self.text[0] == "'" and isinstance(lastNode, (EndTag, RawElement, SelfClosedTag)):
+        if self.text[0] == "'" and isinstance(lastNode, (EndTag, RawElement, SelfClosedTag)) and re.match(r"'\w", self.text):
             self.text = "’" + self.text[1:]
         if "'" in self.text:
             self.text = re.sub(r"(\w)'(\w)", r"\1’\2", self.text)

--- a/bikeshed/h/parser.py
+++ b/bikeshed/h/parser.py
@@ -387,7 +387,8 @@ class ParseFailure(Failure):
         return f"{self.s.loc(self.index)} {self.details}"
 
 
-ResultT = t.TypeVar('ResultT')
+ResultT = t.TypeVar("ResultT")
+
 
 @dataclass
 class Result(t.Generic[ResultT]):
@@ -554,7 +555,11 @@ class Text(ParserNode):
         return self.text
 
     def curlifyApostrophes(self, lastNode: ParserNode | None) -> Text:
-        if self.text[0] == "'" and isinstance(lastNode, (EndTag, RawElement, SelfClosedTag)) and re.match(r"'\w", self.text):
+        if (
+            self.text[0] == "'"
+            and isinstance(lastNode, (EndTag, RawElement, SelfClosedTag))
+            and re.match(r"'\w", self.text)
+        ):
             self.text = "’" + self.text[1:]
         if "'" in self.text:
             self.text = re.sub(r"(\w)'(\w)", r"\1’\2", self.text)
@@ -626,13 +631,13 @@ class SelfClosedTag(ParserNode):
         return dataclasses.replace(self, **kwargs)
 
     @classmethod
-    def fromStartTag(cls, tag: StartTag) -> SelfClosedTag:
+    def fromStartTag(cls: t.Type[SelfClosedTag], tag: StartTag) -> SelfClosedTag:
         return cls(
-            line = tag.line,
-            endLine = tag.endLine,
-            tag = tag.tag,
-            attrs = tag.attrs,
-            classes = tag.classes,
+            line=tag.line,
+            endLine=tag.endLine,
+            tag=tag.tag,
+            attrs=tag.attrs,
+            classes=tag.classes,
         )
 
 

--- a/bikeshed/h/parser.py
+++ b/bikeshed/h/parser.py
@@ -51,6 +51,7 @@ def nodesFromHtml(data: str, config: ParseConfig, startLine: int = 1) -> t.Gener
     while not s.eof(i):
         node, i = parseNode(s, i, lastNode=lastNode).t2
         if node is None:
+            lastNode = None
             text += s[i]
             i += 1
         else:

--- a/bikeshed/t.py
+++ b/bikeshed/t.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 # The only three things that should be available during runtime.
 from typing import TYPE_CHECKING, cast, overload
+# ...except I need these too, to declare a generic class.
+from typing import Generic, TypeVar
 
 if TYPE_CHECKING:
     from typing import (
@@ -16,7 +18,6 @@ if TYPE_CHECKING:
         Deque,
         FrozenSet,
         Generator,
-        Generic,
         Iterable,
         Iterator,
         Literal,
@@ -31,10 +32,9 @@ if TYPE_CHECKING:
         TypeAlias,
         TypedDict,
         TypeGuard,
-        TypeVar,
     )
 
-    from _typeshed import SupportsKeysAndGetItem
+    from _typeshed import SupportsKeysAndGetItem, Self
     from lxml import etree
     from typing_extensions import (
         NotRequired,

--- a/bikeshed/t.py
+++ b/bikeshed/t.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 # The only three things that should be available during runtime.
-from typing import TYPE_CHECKING, cast, overload
 # ...except I need these too, to declare a generic class.
-from typing import Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar, cast, overload
 
 if TYPE_CHECKING:
     from typing import (
@@ -29,12 +28,13 @@ if TYPE_CHECKING:
         Protocol,
         Sequence,
         TextIO,
+        Type,
         TypeAlias,
         TypedDict,
         TypeGuard,
     )
 
-    from _typeshed import SupportsKeysAndGetItem, Self
+    from _typeshed import Self, SupportsKeysAndGetItem
     from lxml import etree
     from typing_extensions import (
         NotRequired,

--- a/tests/github/jfbastien/papers/source/P1152R1.console.txt
+++ b/tests/github/jfbastien/papers/source/P1152R1.console.txt
@@ -1,0 +1,1 @@
+LINE 527:32: Saw the start of a CSS production (like <<foo>>), but couldn't find the end on the same line.

--- a/tests/github/jfbastien/papers/source/P1152R2.console.txt
+++ b/tests/github/jfbastien/papers/source/P1152R2.console.txt
@@ -1,0 +1,2 @@
+LINE 382:42: Saw the start of a CSS production (like <<foo>>), but couldn't find the end on the same line.
+LINE 695:21: Saw the start of a CSS production (like <<foo>>), but couldn't find the end on the same line.

--- a/tests/github/jfbastien/papers/source/P1152R3.console.txt
+++ b/tests/github/jfbastien/papers/source/P1152R3.console.txt
@@ -1,0 +1,2 @@
+LINE 392:42: Saw the start of a CSS production (like <<foo>>), but couldn't find the end on the same line.
+LINE 705:21: Saw the start of a CSS production (like <<foo>>), but couldn't find the end on the same line.

--- a/tests/github/jfbastien/papers/source/P1152R4.console.txt
+++ b/tests/github/jfbastien/papers/source/P1152R4.console.txt
@@ -1,0 +1,2 @@
+LINE 408:42: Saw the start of a CSS production (like <<foo>>), but couldn't find the end on the same line.
+LINE 732:21: Saw the start of a CSS production (like <<foo>>), but couldn't find the end on the same line.


### PR DESCRIPTION
Before I can start recognizing shorthands (which might have parseable HTML inside of them) in the parser, I need the ability to return multiple nodes from a single `parseNode` call.

While I was here, I did a little more cleanup: 
* the curly-quote replacement is now done on text nodes post-production, rather than part of parseNode
* `Stream` now caches its length, to speed up `.eof()` calls. (I presume the chars are immutable anyway.)
* Nodes can now *decrement* the line count as well, if they end up producing more lines than what they occupied in the source. (This can happen in multiline markdown code spans; previously it was hidden by me emitting the whole thing as a single node, so me removing newlines from the text but adding them to the start tag in an attribute was a wash.)
* Result is now properly generic in its contained type, so I can debug better, rather than just spewing `Any` all over. I went ahead and moved away from the slightly silly "return the Failure class itself" design, instead using None as the marker; if None is a valid value you can just get the full val/i/error triple to check for success.
* A limitation of mypy is that it can't express an iterator that returns different types for each iteration. So I had to abandon using `__iter__` to return the `(value, i)` tuple, instead just requiring you to specifically request the `.t2` tuple from each result. (or `.t3` to get the error, or just the `.value` or `.i` if that's all you need).