### PR TITLE
Document (sometimes) required metadata for implementation report and CR deadline

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1231,6 +1231,11 @@ There are several additional optional keys:
 		as linked text.
 		To display WPT results,
 		see [[#testing]].
+	* <dfn>Implementation Report</dfn> must contain a link to 
+		an implementation report, either a hand-written document
+		or just a link to the spec's folder on wpt.fyi. 
+		This is <a href="https://www.w3.org/pubrules/doc/rules/?profile=CR#implReport">required 
+		for W3C Candidate Recommendation Snapshot</a>.
 	* <dfn>Mailing List</dfn> must contain an email address to be used for mailing lists.
 	* <dfn>Mailing List Archives</dfn> must contain a link to the list archives.
 	* <dfn>Issue Tracking</dfn> indicates what and where you track issues,

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1211,7 +1211,7 @@ There are several additional optional keys:
 	* <dfn>Status Text</dfn> allows adding an additional customized sentence that can be used in the document status section.
 	* <dfn>Ignored Terms</dfn> accepts a comma-separated list of terms and makes Bikeshed not emit warnings or errors when attempting to autolink those terms.  Use this to quiet spurious preprocessor warnings caused by you inventing terms (for example, the Variables spec invents custom properties like 'var-foo'), or as a temporary patch when the spec you want to link to doesn't set up its definitions correctly.
 	* <dfn>Date</dfn> must contain a date in YYYY-MM-DD format, which is used instead of today's date for all the date-related stuff in the spec. Alternately it can contain the string `now`, which explicitly indicates a date of precisely when the output is generated.
-	* <dfn>Deadline</dfn> is also a YYYY-MM-DD date, which is used for things like the LCWD Status section, to indicate deadlines.
+	* <dfn>Deadline</dfn> is also a YYYY-MM-DD date, which is used for things like the LCWD and <a href="https://www.w3.org/pubrules/doc/rules/?profile=CR#reviewEndDate">CR Snapshot</a> Status section, to indicate deadlines.
 	* <dfn>Expires</dfn> is also a YYYY-MM-DD date,
 		or can be the string `now` to indicate today's date,
 		or can be an "ISO Duration" like `P1Y` to indicate "+1 year"

--- a/docs/index.html
+++ b/docs/index.html
@@ -1488,9 +1488,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 815accb43, updated Thu Dec 21 14:10:37 2023 -0800" name="generator">
+  <meta content="Bikeshed version 82ce88815, updated Thu Sep 7 16:33:55 2023 -0700" name="generator">
   <link href="https://speced.github.io/bikeshed/" rel="canonical">
-  <meta content="815accb43c1370ab476546acca5e80f08024a1f8" name="revision">
+  <meta content="178fa41ecc3c94893c1692be95ea728e0bcf049b" name="document-revision">
 <style>/* Boilerplate: style-autolinks */
 .css.css, .property.property, .descriptor.descriptor {
     color: var(--a-normal-text);
@@ -1562,6 +1562,7 @@ pre .property::before, pre .property::after {
 }
 </style>
 <style>/* Boilerplate: style-colors */
+
 /* Any --*-text not paired with a --*-bg is assumed to have a transparent bg */
 :root {
     color-scheme: light dark;
@@ -1815,15 +1816,11 @@ figcaption:not(.no-marker)::before {
 :root {
     --dfnpanel-bg: #ddd;
     --dfnpanel-text: var(--text);
-    --dfnpanel-target-bg: #ffc;
-    --dfnpanel-target-outline: orange;
 }
 @media (prefers-color-scheme: dark) {
     :root {
         --dfnpanel-bg: #222;
         --dfnpanel-text: var(--text);
-        --dfnpanel-target-bg: #333;
-        --dfnpanel-target-outline: silver;
     }
 }
 .dfn-panel {
@@ -1846,13 +1843,11 @@ figcaption:not(.no-marker)::before {
 .dfn-panel > b { display: block; }
 .dfn-panel a { color: var(--dfnpanel-text); }
 .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
-.dfn-panel a:focus {
-    outline: 5px auto Highlight;
-    outline: 5px auto -webkit-focus-ring-color;
-}
 .dfn-panel > b + b { margin-top: 0.25em; }
 .dfn-panel ul { padding: 0 0 0 1em; list-style: none; }
 .dfn-panel li a {
+    white-space: pre;
+    display: inline-block;
     max-width: calc(300px - 1.5em - 1em);
     overflow: hidden;
     text-overflow: ellipsis;
@@ -1861,84 +1856,67 @@ figcaption:not(.no-marker)::before {
 .dfn-panel.activated {
     display: inline-block;
     position: fixed;
-    left: 8px;
+    left: .5em;
     bottom: 2em;
     margin: 0 auto;
     max-width: calc(100vw - 1.5em - .4em - .5em);
     max-height: 30vh;
-    transition: left 1s ease-out, bottom 1s ease-out;
 }
 
-.dfn-panel .link-item:hover {
-    text-decoration: underline;
-}
-.dfn-panel .link-item .copy-icon {
-    opacity: 0;
-}
-.dfn-panel .link-item:hover .copy-icon,
-.dfn-panel .link-item .copy-icon:focus {
-    opacity: 1;
-}
-
-.dfn-panel .copy-icon {
-    display: inline-block;
-    margin-right: 0.5em;
-    width: 0.85em;
-    height: 1em;
-    border-radius: 3px;
-    background-color: #ccc;
-    cursor: pointer;
-}
-
-.dfn-panel .copy-icon .icon {
-    width: 100%;
-    height: 100%;
-    background-color: #fff;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    position: relative;
-}
-
-.dfn-panel .copy-icon .icon::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    border: 1px solid black;
-    background-color: #ccc;
-    opacity: 0.25;
-    transform: translate(3px, -3px);
-}
-
-.dfn-panel .copy-icon:active .icon::before {
-    opacity: 1;
-}
-
-.dfn-paneled[role="button"] { cursor: help; }
-
-.highlighted {
-    animation: target-fade 3s;
-}
-
-@keyframes target-fade {
-    from {
-        background-color: var(--dfnpanel-target-bg);
-        outline: 5px solid var(--dfnpanel-target-outline);
-    }
-    to {
-        color: var(--a-normal-text);
-        background-color: transparent;
-        outline: transparent;
-    }
-}
+.dfn-paneled[role="button"] { cursor: pointer; }
 </style>
-<style>/* Boilerplate: style-idl-highlighting */
-pre.idl.highlight {
-    background: var(--borderedblock-bg, var(--def-bg));
+<style>/* Boilerplate: style-dfn-panel */
+:root {
+    --dfnpanel-bg: #ddd;
+    --dfnpanel-text: var(--text);
 }
+@media (prefers-color-scheme: dark) {
+    :root {
+        --dfnpanel-bg: #222;
+        --dfnpanel-text: var(--text);
+    }
+}
+.dfn-panel {
+    position: absolute;
+    z-index: 35;
+    width: 20em;
+    width: 300px;
+    height: auto;
+    max-height: 500px;
+    overflow: auto;
+    padding: 0.5em 0.75em;
+    font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+    background: var(--dfnpanel-bg);
+    color: var(--dfnpanel-text);
+    border: outset 0.2em;
+    white-space: normal; /* in case it's moved into a pre */
+}
+.dfn-panel:not(.on) { display: none; }
+.dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+.dfn-panel > b { display: block; }
+.dfn-panel a { color: var(--dfnpanel-text); }
+.dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+.dfn-panel > b + b { margin-top: 0.25em; }
+.dfn-panel ul { padding: 0 0 0 1em; list-style: none; }
+.dfn-panel li a {
+    white-space: pre;
+    display: inline-block;
+    max-width: calc(300px - 1.5em - 1em);
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.dfn-panel.activated {
+    display: inline-block;
+    position: fixed;
+    left: .5em;
+    bottom: 2em;
+    margin: 0 auto;
+    max-width: calc(100vw - 1.5em - .4em - .5em);
+    max-height: 30vh;
+}
+
+.dfn-paneled[role="button"] { cursor: pointer; }
 </style>
 <style>/* Boilerplate: style-issues */
 a[href].issue-return {
@@ -1950,6 +1928,7 @@ a[href].issue-return {
 }
 </style>
 <style>/* Boilerplate: style-line-highlighting */
+
 :root {
     --highlight-hover-bg: rgba(0, 0, 0, .05);
 }
@@ -1987,6 +1966,7 @@ a[href].issue-return {
     content: attr(data-line-end);
 }
 
+
 @media (prefers-color-scheme: dark) {
     :root {
         --highlight-hover-bg: rgba(255, 255, 255, .05);
@@ -1994,6 +1974,7 @@ a[href].issue-return {
 }
 </style>
 <style>/* Boilerplate: style-line-numbers */
+
 :root {
     --highlight-hover-bg: rgba(0, 0, 0, .05);
 }
@@ -2026,6 +2007,7 @@ a[href].issue-return {
     content: attr(data-line-end);
 }
 
+
 @media (prefers-color-scheme: dark) {
     :root {
         --highlight-hover-bg: rgba(255, 255, 255, .05);
@@ -2043,78 +2025,85 @@ a[href].issue-return {
 }
 </style>
 <style>/* Boilerplate: style-railroad */
-:root {
-    --railroad-bg: hsl(30, 20%, 95%);
-    --railroad-stroke: black;
-    --railroad-fill: hsl(120,100%,90%);
-}
-svg.railroad-diagram {
-    background-color: var(--railroad-bg);
-}
-svg.railroad-diagram path {
-    stroke-width:3px;
-    stroke: var(--railroad-stroke);
-    fill:transparent;
-}
-svg.railroad-diagram text {
-    font: bold 14px monospace;
-    fill: var(--text, currentcolor);
-    text-anchor:middle;
-}
-svg.railroad-diagram text.label {
-    text-anchor:start;
-}
-svg.railroad-diagram text.comment {
-    font:italic 12px monospace;
-}
-svg.railroad-diagram rect {
-    stroke-width:3px;
-    stroke: var(--railroad-stroke);
-    fill: var(--railroad-fill);
-}
 
-@media (prefers-color-scheme: dark) {
     :root {
-        --railroad-bg: rgba(255, 255, 255, .05);
-        --railroad-stroke: #bbb;
-        --railroad-fill: hsla(240deg, 20%, 15%);
+        --railroad-bg: hsl(30, 20%, 95%);
+        --railroad-stroke: black;
+        --railroad-fill: hsl(120,100%,90%);
     }
-}
+    svg.railroad-diagram {
+        background-color: var(--railroad-bg);
+    }
+    svg.railroad-diagram path {
+        stroke-width:3px;
+        stroke: var(--railroad-stroke);
+        fill:transparent;
+    }
+    svg.railroad-diagram text {
+        font: bold 14px monospace;
+        fill: var(--text, currentcolor);
+        text-anchor:middle;
+    }
+    svg.railroad-diagram text.label {
+        text-anchor:start;
+    }
+    svg.railroad-diagram text.comment {
+        font:italic 12px monospace;
+    }
+    svg.railroad-diagram rect {
+        stroke-width:3px;
+        stroke: var(--railroad-stroke);
+        fill: var(--railroad-fill);
+    }
+@media (prefers-color-scheme: dark) {
+        :root {
+            --railroad-bg: rgba(255, 255, 255, .05);
+            --railroad-stroke: #bbb;
+            --railroad-fill: hsla(240deg, 20%, 15%);
+        }
+    }
 </style>
-<style>/* Boilerplate: style-ref-hints */
-:root {
-    --ref-hint-bg: #ddd;
-    --ref-hint-text: var(--text);
-}
-@media (prefers-color-scheme: dark) {
+<style>/* Boilerplate: style-railroad */
+
     :root {
-        --ref-hint-bg: #222;
-        --ref-hint-text: var(--text);
+        --railroad-bg: hsl(30, 20%, 95%);
+        --railroad-stroke: black;
+        --railroad-fill: hsl(120,100%,90%);
     }
-}
-
-.ref-hint {
-    display: inline-block;
-    position: absolute;
-    z-index: 35;
-    width: 20em;
-    width: 300px;
-    height: auto;
-    max-height: 500px;
-    overflow: auto;
-    padding: 0.5em 0.5em;
-    font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
-    background: var(--ref-hint-bg);
-    color: var(--ref-hint-text);
-    border: outset 0.2em;
-    white-space: normal; /* in case it's moved into a pre */
-}
-
-.ref-hint * { margin: 0; padding: 0; text-indent: 0; }
-
-.ref-hint ul { padding: 0 0 0 1em; list-style: none; }
+    svg.railroad-diagram {
+        background-color: var(--railroad-bg);
+    }
+    svg.railroad-diagram path {
+        stroke-width:3px;
+        stroke: var(--railroad-stroke);
+        fill:transparent;
+    }
+    svg.railroad-diagram text {
+        font: bold 14px monospace;
+        fill: var(--text, currentcolor);
+        text-anchor:middle;
+    }
+    svg.railroad-diagram text.label {
+        text-anchor:start;
+    }
+    svg.railroad-diagram text.comment {
+        font:italic 12px monospace;
+    }
+    svg.railroad-diagram rect {
+        stroke-width:3px;
+        stroke: var(--railroad-stroke);
+        fill: var(--railroad-fill);
+    }
+@media (prefers-color-scheme: dark) {
+        :root {
+            --railroad-bg: rgba(255, 255, 255, .05);
+            --railroad-stroke: #bbb;
+            --railroad-fill: hsla(240deg, 20%, 15%);
+        }
+    }
 </style>
 <style>/* Boilerplate: style-selflinks */
+
 :root {
     --selflink-text: white;
     --selflink-bg: gray;
@@ -2174,6 +2163,14 @@ a.self-link::before            { content: "¶"; }
 dfn > a.self-link::before      { content: "#"; }
 </style>
 <style>/* Boilerplate: style-syntax-highlighting */
+
+            pre.idl.highlight {
+                background: var(--borderedblock-bg, var(--def-bg));
+            }
+            
+</style>
+<style>/* Boilerplate: style-syntax-highlighting */
+
 code.highlight { padding: .1em; border-radius: .3em; }
 pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
 
@@ -2230,6 +2227,7 @@ c-[vc] { color: #0077aa } /* Name.Variable.Class */
 c-[vg] { color: #0077aa } /* Name.Variable.Global */
 c-[vi] { color: #0077aa } /* Name.Variable.Instance */
 c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
+
 
 @media (prefers-color-scheme: dark) {
     .highlight:not(.idl) { background: rgba(255, 255, 255, .05); }
@@ -2298,7 +2296,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Bikeshed Documentation</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Living Standard, <time class="dt-updated" datetime="2023-12-21">21 December 2023</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Living Standard, <time class="dt-updated" datetime="2024-01-13">13 January 2024</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2313,7 +2311,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" height="15" src="https://licensebuttons.net/p/zero/1.0/80x15.png" width="80"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 21 December 2023,
+In addition, as of 13 January 2024,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -2801,14 +2799,14 @@ but you can use any equivalent "talk HTTP at a server" command you might have ac
 (same as the <code>--die-on</code> local flag)</p>
     </ul>
    </div>
-   <div class="example" id="example-e056e780">
-    <a class="self-link" href="#example-e056e780"></a> If your source file is online,
+   <div class="example" id="example-4c74cd22">
+    <a class="self-link" href="#example-4c74cd22"></a> If your source file is online,
 	such as in a git repository,
 	you can pass the url directly instead: 
 <pre class="highlight">curl http://api.csswg.org/bikeshed/ -F <c- g>url</c-><c- o>=</c->http://dev.w3.org/csswg/css-syntax/Overview.bs -F <c- g>force</c-><c- o>=</c-><c- m>1</c-> > Overview.html
 </pre>
-    <p>If you are using additional files beyond your plain source file—​local boilerplate files, <a href="#including">sub-document includes</a>, <a href="#custom-dfns">custom definition files</a>,
-	etc—​this is the <em>only</em> way to make those still work
+    <p>If you are using additional files beyond your plain source file—<wbr>local boilerplate files, <a href="#including">sub-document includes</a>, <a href="#custom-dfns">custom definition files</a>,
+	etc—<wbr>this is the <em>only</em> way to make those still work
 	via the curl API;
 	Bikeshed will look for the additional files
 	relative to the source document’s url.</p>
@@ -2875,8 +2873,8 @@ containing:</p>
           <c- c1># Modify as appropriate</c->
           <c- f>GH_PAGES_BRANCH</c-><c- p>:</c-> gh-pages
 
-          <c- c1># if your doc isn't in the root folder,</c->
-          <c- c1># or Bikeshed otherwise can't find it:</c->
+          <c- c1># if your doc isn’t in the root folder,</c->
+          <c- c1># or Bikeshed otherwise can’t find it:</c->
           <c- f>SOURCE</c-><c- p>:</c-> src/spec.bs
 
           <c- c1># output filename defaults to your input</c->
@@ -2884,7 +2882,7 @@ containing:</p>
           <c- c1># but if you want to customize it:</c->
           <c- f>DESTINATION</c-><c- p>:</c-> src/index.html
 </pre>
-   <p>The linked document has a number of usage examples to achieve various outcomes—​simple validation,
+   <p>The linked document has a number of usage examples to achieve various outcomes—<wbr>simple validation,
 auto-publishing on w3.org/TR,
 building multiple specs from a single repository,
 and some others.
@@ -3487,12 +3485,12 @@ and marked-up text in <a data-link-type="dfn" href="#metadata-h1" id="ref-for-me
       </ul>
      </details>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-ed">ED</dfn> (or its synonym <dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-url">URL</dfn>) must contain a link that points to the most current draft
+     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-ed">ED</dfn> (or its synonym <dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-url">URL<a class="self-link" href="#metadata-url"></a></dfn>) must contain a link that points to the most current draft
 (typically the "editor’s draft", or otherwise the version that’s most live and updated).</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-shortname">Shortname</dfn> must contain the spec’s shortname, like "css-lists" or "css-backgrounds".</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-shortname">Shortname<a class="self-link" href="#metadata-shortname"></a></dfn> must contain the spec’s shortname, like "css-lists" or "css-backgrounds".</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-level">Level</dfn> (or <dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-revision">Revision</dfn>, an alias) must contain the spec’s level as an integer or <code>none</code> if the spec does not use levels.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-level">Level<a class="self-link" href="#metadata-level"></a></dfn> (or <dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-revision">Revision<a class="self-link" href="#metadata-revision"></a></dfn>, an alias) must contain the spec’s level as an integer or <code>none</code> if the spec does not use levels.</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-editor">Editor</dfn> must contain an editor’s information.
 This has a special format of comma-separated clauses
@@ -3518,36 +3516,36 @@ Multiple Abstract lines can be used, representing multiple lines of content, as 
    <ul>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-die-on">Die On</dfn> and <dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-die-when">Die When</dfn> give the same control that the <code>--die-on</code> and <code>--die-when</code> command-line options do.
-They take the same values—​a single keyword—​as the corresponding command-line arguments.</p>
+They take the same values—<wbr>a single keyword—<wbr>as the corresponding command-line arguments.</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-h1">H1</dfn> contains the text/markup that goes into the document’s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-h1-element" id="ref-for-the-h1-element④">h1</a></code> element.
 If omitted, this defaults to the value of the <a data-link-type="dfn" href="#metadata-title" id="ref-for-metadata-title①">Title</a> metadata,
 which is usually what you want.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tr">TR</dfn> must contain a link that points to the latest version on /TR.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tr">TR<a class="self-link" href="#metadata-tr"></a></dfn> must contain a link that points to the latest version on /TR.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-canonical-url">Canonical URL</dfn> defines the canonical URL (as used by search engines) for the document; it can be set to "TR" (the default value if TR is defined), "ED", or a specific URL.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-canonical-url">Canonical URL<a class="self-link" href="#metadata-canonical-url"></a></dfn> defines the canonical URL (as used by search engines) for the document; it can be set to "TR" (the default value if TR is defined), "ED", or a specific URL.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-favicon">Favicon</dfn> defines the favicon URL for the document; it only supports one single URL.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-favicon">Favicon<a class="self-link" href="#metadata-favicon"></a></dfn> defines the favicon URL for the document; it only supports one single URL.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-logo">Logo</dfn> defines the logo url for the document; it only supports one single url.
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-logo">Logo<a class="self-link" href="#metadata-logo"></a></dfn> defines the logo url for the document; it only supports one single url.
 This URL can be used via the <code>[LOGO]</code> text macro (<a href="#text-macros">§ 12.3 Text Macros</a>),
 and is by default used by the <code>logo</code> boilerplate section (<a href="#bp-sections">§ 12.5 Boilerplate Sections</a>).</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-former-editor">Former Editor</dfn> must contain a former editor’s information, in the same format as <a data-link-type="dfn" href="#metadata-editor" id="ref-for-metadata-editor①">Editor</a>.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-former-editor">Former Editor<a class="self-link" href="#metadata-former-editor"></a></dfn> must contain a former editor’s information, in the same format as <a data-link-type="dfn" href="#metadata-editor" id="ref-for-metadata-editor①">Editor</a>.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-warning">Warning</dfn> must contain either "Obsolete", "Not Ready", "New Version XXX", "Replaced by XXX", "Commit deadb33f http://example.com/url/to/deadb33f replaced by XXX", "Branch XXX http://example.com/url/to/XXX replaced by YYY", or "Custom", which triggers the appropriate warning message in the boilerplate.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-warning">Warning<a class="self-link" href="#metadata-warning"></a></dfn> must contain either "Obsolete", "Not Ready", "New Version XXX", "Replaced by XXX", "Commit deadb33f http://example.com/url/to/deadb33f replaced by XXX", "Branch XXX http://example.com/url/to/XXX replaced by YYY", or "Custom", which triggers the appropriate warning message in the boilerplate.</p>
      <p>If set to "Custom", the metadata keys <a data-link-type="dfn" href="#metadata-custom-warning-title" id="ref-for-metadata-custom-warning-title">Custom Warning Title</a> and <a data-link-type="dfn" href="#metadata-custom-warning-text" id="ref-for-metadata-custom-warning-text">Custom Warning Text</a> control what the warning contains.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-previous-version">Previous Version</dfn> can contain either a URL to a previously-published version (such as versions published on w3.org/TR),
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-previous-version">Previous Version<a class="self-link" href="#metadata-previous-version"></a></dfn> can contain either a URL to a previously-published version (such as versions published on w3.org/TR),
 or the value <code>from biblio</code> or <code>from biblio my-spec-1</code>.</p>
      <p>Links get displayed literally in the spec’s metadata section. "from biblio" entries instead auto-generate a link to the latest dated version of the given versioned shortname that appears in the biblio database. (If omitted, the spec’s own versioned shortname is implicitly used.)</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-at-risk">At Risk</dfn> must contain an at-risk feature.  You can specify this key more than once for multiple entries.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-at-risk">At Risk<a class="self-link" href="#metadata-at-risk"></a></dfn> must contain an at-risk feature.  You can specify this key more than once for multiple entries.</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-group">Group</dfn> must contain the name of the group the spec is being generated for.  This is used by the boilerplate generation to select the correct file.  If omitted, it defaults to a generic set of boilerplate.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-dark-mode">Dark Mode</dfn> must contain a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish">boolish</a> for whether or not Bikeshed includes darkmode-relevant colors/etc
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-dark-mode">Dark Mode<a class="self-link" href="#metadata-dark-mode"></a></dfn> must contain a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish">boolish</a> for whether or not Bikeshed includes darkmode-relevant colors/etc
 for all of its built-in styles.</p>
      <p>It defaults to "on",
 but if you provide custom styles that are not darkmode-aware,
@@ -3555,35 +3553,41 @@ you should set this "off"
 so Bikeshed features don’t render for darkmode
 and become unreadable against your lightmode styles.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-status-text">Status Text</dfn> allows adding an additional customized sentence that can be used in the document status section.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-status-text">Status Text<a class="self-link" href="#metadata-status-text"></a></dfn> allows adding an additional customized sentence that can be used in the document status section.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-ignored-terms">Ignored Terms</dfn> accepts a comma-separated list of terms and makes Bikeshed not emit warnings or errors when attempting to autolink those terms.  Use this to quiet spurious preprocessor warnings caused by you inventing terms (for example, the Variables spec invents custom properties like 'var-foo'), or as a temporary patch when the spec you want to link to doesn’t set up its definitions correctly.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-ignored-terms">Ignored Terms<a class="self-link" href="#metadata-ignored-terms"></a></dfn> accepts a comma-separated list of terms and makes Bikeshed not emit warnings or errors when attempting to autolink those terms.  Use this to quiet spurious preprocessor warnings caused by you inventing terms (for example, the Variables spec invents custom properties like 'var-foo'), or as a temporary patch when the spec you want to link to doesn’t set up its definitions correctly.</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-date">Date</dfn> must contain a date in YYYY-MM-DD format, which is used instead of today’s date for all the date-related stuff in the spec. Alternately it can contain the string <code>now</code>, which explicitly indicates a date of precisely when the output is generated.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-deadline">Deadline</dfn> is also a YYYY-MM-DD date, which is used for things like the LCWD Status section, to indicate deadlines.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-deadline">Deadline<a class="self-link" href="#metadata-deadline"></a></dfn> is also a YYYY-MM-DD date, which is used for things like the LCWD and <a href="https://www.w3.org/pubrules/doc/rules/?profile=CR#reviewEndDate">CR Snapshot</a> Status section, to indicate deadlines.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-expires">Expires</dfn> is also a YYYY-MM-DD date,
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-expires">Expires<a class="self-link" href="#metadata-expires"></a></dfn> is also a YYYY-MM-DD date,
 or can be the string <code>now</code> to indicate today’s date,
 or can be an "ISO Duration" like <code>P1Y</code> to indicate "+1 year"
 from the <a data-link-type="dfn" href="#metadata-date" id="ref-for-metadata-date">Date</a> metadata
 (or the spec’s generation date if that’s not specified),
-and indicates when the document should be considered "expired"—​before the expiration date an (initially closed) warning about the upcoming expiration is automatically included in the document;
+and indicates when the document should be considered "expired"—<wbr>before the expiration date an (initially closed) warning about the upcoming expiration is automatically included in the document;
 afterwards the warning defaults to being open and annoying.</p>
      <p>It can also take a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish①">boolish</a> false value or <code>never</code> to indicate it never expires;
 this is just the default value,
 so these values are only useful for turning off a default expiration
 established by your default metadata.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-test-suite">Test Suite</dfn> must contain a link to the test suite (like <code>https://test.csswg.org/suites/css-flexbox-1_dev/nightly-unstable/</code>).</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-test-suite">Test Suite<a class="self-link" href="#metadata-test-suite"></a></dfn> must contain a link to the test suite (like <code>https://test.csswg.org/suites/css-flexbox-1_dev/nightly-unstable/</code>).</p>
      <p class="note" role="note"><span class="marker">Note:</span> This merely displays a "Test Suite" item in the spec’s header-list,
 as linked text.
 To display WPT results,
 see <a href="#testing">§ 11 Testing Integration With WPT</a>.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-mailing-list">Mailing List</dfn> must contain an email address to be used for mailing lists.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-implementation-report">Implementation Report<a class="self-link" href="#metadata-implementation-report"></a></dfn> must contain a link to
+an implementation report, either a hand-written document
+or just a link to the spec’s folder on wpt.fyi. 
+This is <a href="https://www.w3.org/pubrules/doc/rules/?profile=CR#implReport">required 
+for W3C Candidate Recommendation Snapshot</a>.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-mailing-list-archives">Mailing List Archives</dfn> must contain a link to the list archives.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-mailing-list">Mailing List<a class="self-link" href="#metadata-mailing-list"></a></dfn> must contain an email address to be used for mailing lists.</p>
+    <li data-md>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-mailing-list-archives">Mailing List Archives<a class="self-link" href="#metadata-mailing-list-archives"></a></dfn> must contain a link to the list archives.</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-issue-tracking">Issue Tracking</dfn> indicates what and where you track issues,
 and will result in an "Issue Tracking" entry in your spec header.
@@ -3598,29 +3602,29 @@ you’ll automatically get a "GitHub" annotation.</p>
      <p>You can turn off the spec-header entry entirely with <code>Boilerplate: feedback-header off</code>,
 or just turn off the GitHub entry specifically with <code>Boilerplate: repository-issue-tracking off</code>.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-issue-tracker-template">Issue Tracker Template</dfn> specifies a url template used to point <a href="#remote-issues">remote issues</a> at your issue tracker of choice. It takes a url, with <code>{0}</code> in the place where you want the remote identifier to go.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-issue-tracker-template">Issue Tracker Template<a class="self-link" href="#metadata-issue-tracker-template"></a></dfn> specifies a url template used to point <a href="#remote-issues">remote issues</a> at your issue tracker of choice. It takes a url, with <code>{0}</code> in the place where you want the remote identifier to go.</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-translation">Translation</dfn> indicates a translation of the document. At minimum it consists of a language code (BCP47 format) and a url. Optionally, it can contain comma-separated <code>name [name-in-spec-language]</code> and <code>native-name [name-in-translation-language]</code>, but if Bikeshed knows about that language, these will be filled in for you.  (If Bikeshed doesn’t know about a given language, let me know what its name is in English and itself!)</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-indent">Indent</dfn> tells Bikeshed how many spaces you prefer to use to indent your source code,
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-indent">Indent<a class="self-link" href="#metadata-indent"></a></dfn> tells Bikeshed how many spaces you prefer to use to indent your source code,
 so it can properly parse your Markdown and data-blocks.
 It takes a single integer,
 and defaults to <code>4</code> if unspecified.
 (Of course, using tabs avoids this entirely,
 as one tab is always one indent.)</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-no-editor">No Editor</dfn> lets you omit the <code>Editor</code> metadata without an error.
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-no-editor">No Editor<a class="self-link" href="#metadata-no-editor"></a></dfn> lets you omit the <code>Editor</code> metadata without an error.
 It takes a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish②">boolish</a> value.
 This shouldn’t generally be used;
 even if your organization doesn’t privilege editors in any way,
 putting the organization itself in the <code>Editor</code> field
 meets the intent while still producing useful information for readers of the spec.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-no-abstract">No Abstract</dfn> lets you omit the <code>Abstract</code> metadata without an error.
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-no-abstract">No Abstract<a class="self-link" href="#metadata-no-abstract"></a></dfn> lets you omit the <code>Abstract</code> metadata without an error.
 It takes a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish③">boolish</a> value.
 This should only be used for very small and trivial documents, where the abstract would just be repeating the title of the more-or-less.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-editor-term">Editor Term</dfn> is a pair of comma-separated terms giving the singular and plural terms to refer to editors with, if you want something other than the default "Editor(s)".</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-editor-term">Editor Term<a class="self-link" href="#metadata-editor-term"></a></dfn> is a pair of comma-separated terms giving the singular and plural terms to refer to editors with, if you want something other than the default "Editor(s)".</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-default-ref-status">Default Ref Status</dfn> takes the values "current" or "snapshot",
 and selects which URL you want to default to
@@ -3655,13 +3659,13 @@ displaying as their shortname and linking to the referenced document ("direct").
      </ul>
      <p>Everything but <code>markdown</code> defaults to "on".</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-text-macro">Text Macro</dfn> lets you specify custom text macros, like <code>[TITLE]</code> or <code>[DATE]</code>, letting you fill in different text when building a spec in multiple ways.  (This is mostly useful as a command-line option.)  Each <a data-link-type="dfn" href="#metadata-text-macro" id="ref-for-metadata-text-macro">Text Macro</a> line consists of a macro name, which must be uppercase and alphanumeric, followed by the text it will get replaced with.</p>
+     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-text-macro">Text Macro</dfn> lets you specify custom text macros, like <code>Bikeshed Documentation</code> or <code>13 January 2024</code>, letting you fill in different text when building a spec in multiple ways.  (This is mostly useful as a command-line option.)  Each <a data-link-type="dfn" href="#metadata-text-macro" id="ref-for-metadata-text-macro">Text Macro</a> line consists of a macro name, which must be uppercase and alphanumeric, followed by the text it will get replaced with.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-work-status">Work Status</dfn> indicates the status of the document, in a way unrelated to the publication status of <a data-link-type="dfn" href="#metadata-status" id="ref-for-metadata-status">Status</a>.  It must be one of (completed, stable, testing, refining, revising, exploring, rewriting, abandoned), with those terms defined in <a href="http://fantasai.inkedblade.net/weblog/2011/inside-csswg/process">Fantasai’s blog</a>. This just sets the <code>[WORKSTATUS]</code> text macro to the corresponding word, used in some of the boilerplates to pipe the metadata to scraping tools.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-work-status">Work Status<a class="self-link" href="#metadata-work-status"></a></dfn> indicates the status of the document, in a way unrelated to the publication status of <a data-link-type="dfn" href="#metadata-status" id="ref-for-metadata-status">Status</a>.  It must be one of (completed, stable, testing, refining, revising, exploring, rewriting, abandoned), with those terms defined in <a href="http://fantasai.inkedblade.net/weblog/2011/inside-csswg/process">Fantasai’s blog</a>. This just sets the <code>[WORKSTATUS]</code> text macro to the corresponding word, used in some of the boilerplates to pipe the metadata to scraping tools.</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-repository">Repository</dfn> indicates the repository the spec is being tracked in.
 You can specify a url followed by a "short name" for it,
-and it populates the <code>[REPOSITORY]</code> and <code>[REPOSITORYURL]</code> text macros accordingly.
+and it populates the <code>speced/bikeshed</code> and <code>https://github.com/speced/bikeshed</code> text macros accordingly.
 If you are using GitHub,
 you can just specify <code>username/repo</code>,
 and Bikeshed will infer the rest for you.
@@ -3688,30 +3692,30 @@ they’ll have their contents replaced by just the title of the remote issue
 If your <a data-link-type="dfn" href="#metadata-repository" id="ref-for-metadata-repository①">Repository</a> is set up to a GitHub repo, <a href="#remote-issues">remote issues</a> with just an issue number
 will also be expanded to the corresponding issue from your repository.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-opaque-elements">Opaque Elements</dfn> and <dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-block-elements">Block Elements</dfn> are a comma-separated list of custom element names, to help control Bikeshed’s parsing and serialization. By default, custom elements are treated as inline; marking an element as "opaque" makes it like <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element" id="ref-for-the-pre-element">pre</a></code>, so shorthands and Markdown aren’t processed in it, and it’s serialized precisely as entered; marking an element as "block" makes it interrupt paragraphs when it starts a line, and causes the pretty-printer to serialize it in a block-like way.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-opaque-elements">Opaque Elements<a class="self-link" href="#metadata-opaque-elements"></a></dfn> and <dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-block-elements">Block Elements<a class="self-link" href="#metadata-block-elements"></a></dfn> are a comma-separated list of custom element names, to help control Bikeshed’s parsing and serialization. By default, custom elements are treated as inline; marking an element as "opaque" makes it like <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element" id="ref-for-the-pre-element">pre</a></code>, so shorthands and Markdown aren’t processed in it, and it’s serialized precisely as entered; marking an element as "block" makes it interrupt paragraphs when it starts a line, and causes the pretty-printer to serialize it in a block-like way.</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-note-class">Note Class</dfn>, <dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-issue-class">Issue Class</dfn>, <dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-assertion-class">Assertion Class</dfn>, and <dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-advisement-class">Advisement Class</dfn> specify the class name given to paragraphs using the note/issue/advisement <a data-link-type="dfn" href="#metadata-markup-shorthands" id="ref-for-metadata-markup-shorthands">markup shorthand</a>.  They default to "note", "issue", and "advisement".</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-informative-classes">Informative Classes</dfn> is a comma-separated list of classes that should be considered "informative" or "non-normative"—​elements with these classes must not contain definitions or requirements,
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-informative-classes">Informative Classes<a class="self-link" href="#metadata-informative-classes"></a></dfn> is a comma-separated list of classes that should be considered "informative" or "non-normative"—<wbr>elements with these classes must not contain definitions or requirements,
 and Bikeshed will verify this for you
 (either automatically, or via the <code>Complain About: accidental-2119</code> metadata).
 "note", "example", "informative", and "non-normative" all trigger this behavior by default.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-translate-ids">Translate IDs</dfn> maps Bikeshed-generated IDs to manually-specified IDs, for cases where you need to manually specify an ID but it’s generated by Bikeshed in a hard-to-override way (like IDL blocks).  It takes a comma separated list of Bikeshed IDs and new IDs.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-translate-ids">Translate IDs<a class="self-link" href="#metadata-translate-ids"></a></dfn> maps Bikeshed-generated IDs to manually-specified IDs, for cases where you need to manually specify an ID but it’s generated by Bikeshed in a hard-to-override way (like IDL blocks).  It takes a comma separated list of Bikeshed IDs and new IDs.</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-default-highlight">Default Highlight</dfn> specifies the default highlighting language. Every <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element" id="ref-for-the-pre-element①">pre</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/obsolete.html#xmp" id="ref-for-xmp">xmp</a></code>, and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-code-element" id="ref-for-the-code-element">code</a></code> will automatically be highlighted according to the specified language, unless they or an ancestor specifies a different <code>highlight=foo</code> or <code>nohighlight</code> attribute overriding it.</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-line-numbers">Line Numbers</dfn> is a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish⑥">boolish</a> specifying whether, by default, code blocks (<code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element" id="ref-for-the-pre-element②">pre</a></code> and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/obsolete.html#xmp" id="ref-for-xmp①">xmp</a></code>) should get line numbers. Defaults to off.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-toggle-diffs">Toggle Diffs</dfn> is a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish⑦">boolish</a> that specifies whether Bikeshed should include a 'Hide deleted text' button to toggle hiding <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/edits.html#the-del-element" id="ref-for-the-del-element">del</a></code> elements in your spec header. Defaults to off.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-toggle-diffs">Toggle Diffs<a class="self-link" href="#metadata-toggle-diffs"></a></dfn> is a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish⑦">boolish</a> that specifies whether Bikeshed should include a 'Hide deleted text' button to toggle hiding <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/edits.html#the-del-element" id="ref-for-the-del-element">del</a></code> elements in your spec header. Defaults to off.</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-boilerplate">Boilerplate</dfn> toggles the generation of individual <a href="#bp-sections">boilerplate sections</a>. Its value is a comma-separated list of section name and <a data-link-type="dfn" href="#boolish" id="ref-for-boolish⑧">boolish</a> value, e.g. <code>Boilerplate: issues-index no</code> to disable the list of issues.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-local-boilerplate">Local Boilerplate</dfn> tells Bikeshed which boilerplate include files to look for relative to the specification (as opposed to inside the Bikeshed source). Its value is a comma-separated list of include file basename and <a data-link-type="dfn" href="#boolish" id="ref-for-boolish⑨">boolish</a> value, e.g. <code>Local Boilerplate: footer yes</code> to look for <code>footer.include</code> and <code>footer-[STATUS].include</code> next to the specification. This also works for default includes that aren’t quite boilerplate like <a href="#default-metadata">defaults.include</a>, <a href="#computed-metadata">computed-metadata.include</a>, and <a href="#echidna-hooks">bs-extensions.include</a>.</p>
+     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-local-boilerplate">Local Boilerplate</dfn> tells Bikeshed which boilerplate include files to look for relative to the specification (as opposed to inside the Bikeshed source). Its value is a comma-separated list of include file basename and <a data-link-type="dfn" href="#boolish" id="ref-for-boolish⑨">boolish</a> value, e.g. <code>Local Boilerplate: footer yes</code> to look for <code>footer.include</code> and <code>footer-LS.include</code> next to the specification. This also works for default includes that aren’t quite boilerplate like <a href="#default-metadata">defaults.include</a>, <a href="#computed-metadata">computed-metadata.include</a>, and <a href="#echidna-hooks">bs-extensions.include</a>.</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-external-infotrees">External Infotrees</dfn> lists which of <a href="#custom-dfns">anchors.bsdata</a> and <a href="#link-defaults">link-defaults.infotree</a> should be found in files adjacent to the specification instead of in <code>&lt;pre></code> blocks inside it.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-complain-about">Complain About</dfn> indicates what nits you’d like Bikeshed to complain about, that are normally too noisy to be turned on by default. Its value is a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish①⓪">boolish</a> list like <a data-link-type="dfn" href="#metadata-markup-shorthands" id="ref-for-metadata-markup-shorthands①">Markup Shorthands</a>. Accepted values are:</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-complain-about">Complain About<a class="self-link" href="#metadata-complain-about"></a></dfn> indicates what nits you’d like Bikeshed to complain about, that are normally too noisy to be turned on by default. Its value is a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish①⓪">boolish</a> list like <a data-link-type="dfn" href="#metadata-markup-shorthands" id="ref-for-metadata-markup-shorthands①">Markup Shorthands</a>. Accepted values are:</p>
      <dl>
       <dt data-md><code>accidental-2119</code>
       <dd data-md>
@@ -3740,7 +3744,7 @@ then spaces to align the preformatted text.</p>
        <p>This value <em>is turned on by default</em>. You can turn it off with <code>Complain About: mixed-indents no</code></p>
      </dl>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-infer-css-dfns">Infer CSS Dfns</dfn> is a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish①①">boolish</a> that specifies whether Bikeshed should try to "infer" what type a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element" id="ref-for-the-dfn-element">dfn</a></code> is by looking at the text,
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-infer-css-dfns">Infer CSS Dfns<a class="self-link" href="#metadata-infer-css-dfns"></a></dfn> is a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish①①">boolish</a> that specifies whether Bikeshed should try to "infer" what type a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element" id="ref-for-the-dfn-element">dfn</a></code> is by looking at the text,
 using CSS-biased heuristics.
 (In other words, this’ll only auto-detect certain CSS types.)
 Defaults to off.</p>
@@ -3756,12 +3760,12 @@ but it requires you to specify more <code>for</code> values on your autolinks
 even when it’s not necessary to disambiguate things,
 so it’s off by default.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-max-toc-depth">Max ToC Depth</dfn> specifies the maximum depth you want the ToC to generate to. It can be the value "none", meaning generate the ToC normally, or an integer between 1 and 5. It defaults to "none".</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-max-toc-depth">Max ToC Depth<a class="self-link" href="#metadata-max-toc-depth"></a></dfn> specifies the maximum depth you want the ToC to generate to. It can be the value "none", meaning generate the ToC normally, or an integer between 1 and 5. It defaults to "none".</p>
     <li data-md>
      <p>Several keys related to the <a href="https://developer.mozilla.org/en-US/docs/Web">MDN</a> project:</p>
      <ul>
       <li data-md>
-       <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-include-mdn-panels">Include MDN Panels</dfn> is a <a data-link-type="dfn" href="#soft-boolish" id="ref-for-soft-boolish">soft boolish</a> that specifies whether to include <a href="https://developer.mozilla.org/en-US/docs/Web">MDN</a> panels or not.
+       <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-include-mdn-panels">Include MDN Panels<a class="self-link" href="#metadata-include-mdn-panels"></a></dfn> is a <a data-link-type="dfn" href="#soft-boolish" id="ref-for-soft-boolish">soft boolish</a> that specifies whether to include <a href="https://developer.mozilla.org/en-US/docs/Web">MDN</a> panels or not.
 If it’s turned on, MDN panels will be added automatically in output,
 positioned to line up with the elements which define the features the panels annotate.
 Each MDN panel includes a hyperlink to the MDN article for the feature it annotates,
@@ -3777,7 +3781,7 @@ you can pass one of the "maybe" values of a <a data-link-type="dfn" href="#soft-
 otherwise, if directly turned on,
 it will emit a fatal error if it can’t find your spec.</p>
       <li data-md>
-       <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-ignore-mdn-failure">Ignore MDN Failure</dfn> takes one of the IDs that MDN is attempting to target,
+       <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-ignore-mdn-failure">Ignore MDN Failure<a class="self-link" href="#metadata-ignore-mdn-failure"></a></dfn> takes one of the IDs that MDN is attempting to target,
 and prevents Bikeshed from emitting a warning
 if it can’t find that ID.
 You can supply this multiple times
@@ -3802,7 +3806,7 @@ and if there are any Can I Use features whose URL includes one of the specified 
 and the feature isn’t already specified somewhere in your spec,
 it will log a warning for you.</p>
       <li data-md>
-       <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-ignore-can-i-use-url-failure">Ignore Can I Use URL Failure</dfn> takes one of the URLs specified in <a data-link-type="dfn" href="#metadata-can-i-use-url" id="ref-for-metadata-can-i-use-url">Can I Use URL</a>,
+       <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-ignore-can-i-use-url-failure">Ignore Can I Use URL Failure<a class="self-link" href="#metadata-ignore-can-i-use-url-failure"></a></dfn> takes one of the URLs specified in <a data-link-type="dfn" href="#metadata-can-i-use-url" id="ref-for-metadata-can-i-use-url">Can I Use URL</a>,
 and suppresses the warning that Bikeshed emits if the URL doesn’t show up in the Can I Use database.
 (This error exists to help catch typos,
 rather than just letting it silently fail.)
@@ -3826,7 +3830,7 @@ for common errors that would make a spec fail the W3C’s PubRules check.
 This is applied automatically when you run the <a href="#cli-echidna">Echidna</a> command to publish your spec,
 but you can use it manually to check precisely what your spec will look like when published.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-use-dfn-panels">Use Dfn Panels</dfn> is a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish①⑤">boolish</a> that determines
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-use-dfn-panels">Use Dfn Panels<a class="self-link" href="#metadata-use-dfn-panels"></a></dfn> is a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish①⑤">boolish</a> that determines
 whether "definition panels" are generated for every definition;
 it defaults to true.
 These "panels" show up when you click on a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element" id="ref-for-the-dfn-element②">dfn</a></code>,
@@ -3836,13 +3840,13 @@ you can suppress this with <code>Boilerplate: script-dfn-panel no, style-dfn-pan
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-metadata-include">Metadata Include</dfn> and <dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-metadata-order">Metadata Order</dfn> are defined in <a href="#rearranging-metadata">§ 12.2 Rearranging and Excluding "Spec Metadata"</a>.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-remove-multiple-links">Remove Multiple Links</dfn> is a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish①⑥">boolish</a> (defaulting to false)
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-remove-multiple-links">Remove Multiple Links<a class="self-link" href="#metadata-remove-multiple-links"></a></dfn> is a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish①⑥">boolish</a> (defaulting to false)
 that controls whether Bikeshed automatically suppresses multiple autolinks to the same term
 in a single paragraph.
 (That is, if multiple autolinks point to the same URL within a single parent element,
 all but the first will be reverted to plain <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element" id="ref-for-the-span-element">span</a></code>s.)</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-slim-build-artifact">Slim Build Artifact</dfn> is a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish①⑦">boolish</a> (defaulting to false)
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-slim-build-artifact">Slim Build Artifact<a class="self-link" href="#metadata-slim-build-artifact"></a></dfn> is a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish①⑦">boolish</a> (defaulting to false)
 that specifies whether or not Bikeshed should try and "slim" the output,
 to make it more appropriate as an obvious "build artifact",
 rather than an active usable spec.
@@ -3850,10 +3854,10 @@ This turns off various usability features which otherwise bloat your HTML,
 and which aren’t necessary if the output isn’t intended to be actively used by humans.
 The exact set of features that are affected by this will evolve over time.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-required-ids">Required IDs</dfn> is a list of IDs that the document <em>must</em> contain.
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-required-ids">Required IDs<a class="self-link" href="#metadata-required-ids"></a></dfn> is a list of IDs that the document <em>must</em> contain.
 This can be used to ensure that certain links into the document don’t rot over time.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-force-crossorigin">Force Crossorigin</dfn> is a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish①⑧">boolish</a> that auto-adds the <code>crossorigin=anonymous</code> attribute
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-force-crossorigin">Force Crossorigin<a class="self-link" href="#metadata-force-crossorigin"></a></dfn> is a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish①⑧">boolish</a> that auto-adds the <code>crossorigin=anonymous</code> attribute
 to every relevant element (<code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element" id="ref-for-the-link-element">link</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script">script</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element" id="ref-for-the-img-element">img</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#audio" id="ref-for-audio">audio</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video" id="ref-for-video">video</a></code>).
 You can set a different <code>crossorigin</code> value manually on the element,
 or skip the element entirely by putting <code>nocrossorigin</code> on it or an ancestor.</p>
@@ -3864,18 +3868,18 @@ that specifies a common path prefix for all of the tests in your <code><a data-l
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-wpt-display">WPT Display</dfn> takes the values "none", "closed", "open", or "inline",
 and specifies whether and how <code><a data-link-type="element" href="#wpt-element" id="ref-for-wpt-element①">wpt</a></code> elements display anything in the output document.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tracking-vector-class">Tracking Vector Class</dfn> is the HTML <code>class</code> attribute value used on the link inserted in elements annotated with the <code>tracking-vector</code> attribute.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tracking-vector-class">Tracking Vector Class<a class="self-link" href="#metadata-tracking-vector-class"></a></dfn> is the HTML <code>class</code> attribute value used on the link inserted in elements annotated with the <code>tracking-vector</code> attribute.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tracking-vector-image">Tracking Vector Image</dfn> is an image URL that can be used to represent tracking vectors with an external image.
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tracking-vector-image">Tracking Vector Image<a class="self-link" href="#metadata-tracking-vector-image"></a></dfn> is an image URL that can be used to represent tracking vectors with an external image.
 Otherwise an inline SVG is used. The image is a child of the aforementioned link.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tracking-vector-image-width">Tracking Vector Image Width</dfn> is the width of the external image, if any.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tracking-vector-image-width">Tracking Vector Image Width<a class="self-link" href="#metadata-tracking-vector-image-width"></a></dfn> is the width of the external image, if any.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tracking-vector-image-height">Tracking Vector Image Height</dfn> is the height of the external image, if any.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tracking-vector-image-height">Tracking Vector Image Height<a class="self-link" href="#metadata-tracking-vector-image-height"></a></dfn> is the height of the external image, if any.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tracking-vector-alt-text">Tracking Vector Alt Text</dfn> is the replacement text for the inline SVG or external image.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tracking-vector-alt-text">Tracking Vector Alt Text<a class="self-link" href="#metadata-tracking-vector-alt-text"></a></dfn> is the replacement text for the inline SVG or external image.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tracking-vector-title">Tracking Vector Title</dfn> is the title for the inline SVG or external image.</p>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tracking-vector-title">Tracking Vector Title<a class="self-link" href="#metadata-tracking-vector-title"></a></dfn> is the title for the inline SVG or external image.</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-image-auto-size">Image Auto Size</dfn> is a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish①⑨">boolish</a> (defaulting to true)
 that specifies whether Bikeshed should <a href="#img-size">automatically detect the size</a> of images used in the document.</p>
@@ -3902,12 +3906,12 @@ they’re documented here for understanding.
 Each one recommends what you should be using instead.</p>
    <ul>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-use-i-autolinks">Use &lt;i> Autolinks</dfn> turns on legacy support for using <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-i-element" id="ref-for-the-i-element">i</a></code> elements as "dfn" autolinks.
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-use-i-autolinks">Use &lt;i> Autolinks<a class="self-link" href="#metadata-use-i-autolinks"></a></dfn> turns on legacy support for using <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-i-element" id="ref-for-the-i-element">i</a></code> elements as "dfn" autolinks.
 It takes a <a data-link-type="dfn" href="#boolish" id="ref-for-boolish②①">boolish</a> value.</p>
      <p>Instead of using this,
 just use the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element">a</a></code> element to autolink, as usual.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-link-defaults">Link Defaults</dfn> lets you specify a default spec for particular autolinks to link to.
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-link-defaults">Link Defaults<a class="self-link" href="#metadata-link-defaults"></a></dfn> lets you specify a default spec for particular autolinks to link to.
 The value is a comma-separated list of entries,
 where each entry is a versioned spec shortname,
 followed by a parenthesized link type,
@@ -3917,7 +3921,7 @@ For example, <code>Link Defaults: html (dfn) allowed to show a popup/in parallel
 use a <code>&lt;pre class=link-defaults></code> block,
 as the error message suggests when this is necessary.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-ignored-vars">Ignored Vars</dfn> accepts a comma-separated list of variable names,
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-ignored-vars">Ignored Vars<a class="self-link" href="#metadata-ignored-vars"></a></dfn> accepts a comma-separated list of variable names,
 and makes Bikeshed not emit warnings or errors about them being used only once in the document/algorithm.</p>
      <p>Instead of using this,
 put an <code>ignore</code> attribute on the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-var-element" id="ref-for-the-var-element①">var</a></code> in question.</p>
@@ -4076,7 +4080,7 @@ It also does not recognize "link references"
 and referring to it by reference instead).</p>
    <p>In addition to standard (CommonMark) Markdown,
 Bikeshed also recognizes <strong>definition lists</strong>, with the following format:</p>
-<pre>Here's the dl syntax:
+<pre>Here’s the dl syntax:
 
 : key
 :: val
@@ -4198,7 +4202,7 @@ you can instruct Bikeshed to ignore the error by adding an <code>ignore</code> a
 (There’s no way to do this with the <code>|foo|</code> syntax;
 you have to convert it back to an actual <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-var-element" id="ref-for-the-var-element⑤">var</a></code> element.)</p>
    <h3 class="heading settled" data-level="5.6" id="code-blocks"><span class="secno">5.6. </span><span class="content">Code Blocks (<code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element" id="ref-for-the-pre-element⑤">pre</a></code>, etc)</span><a class="self-link" href="#code-blocks"></a></h3>
-   <p>Bikeshed has several nice features related to "code blocks"—​<code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element" id="ref-for-the-pre-element⑥">pre</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/obsolete.html#xmp" id="ref-for-xmp②">xmp</a></code>, and sometimes <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-code-element" id="ref-for-the-code-element①">code</a></code>.</p>
+   <p>Bikeshed has several nice features related to "code blocks"—<wbr><code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element" id="ref-for-the-pre-element⑥">pre</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/obsolete.html#xmp" id="ref-for-xmp②">xmp</a></code>, and sometimes <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-code-element" id="ref-for-the-code-element①">code</a></code>.</p>
    <h4 class="heading settled" data-level="5.6.1" id="pre-whitespace-stripping"><span class="secno">5.6.1. </span><span class="content"><code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element" id="ref-for-the-pre-element⑦">pre</a></code> whitespace stripping</span><a class="self-link" href="#pre-whitespace-stripping"></a></h4>
    <p>Using a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element" id="ref-for-the-pre-element⑧">pre</a></code> element in HTML is unsatisfying,
 because it forces you to break your indentation strategy,
@@ -4429,7 +4433,7 @@ macros:
 </pre>
    <p>With the above code, you can use <code>[FOO]</code> and <code>[BAZ]</code> macros inside the include file,
 and they’ll be substituted with "bar" and "qux qux qux", respectively.
-(Remember that you can mark text macros as optional by appending a <code>?</code>, like <code>[FOO?]</code>,
+(Remember that you can mark text macros as optional by appending a <code>?</code>, like <code></code>,
 in which case they’ll be replaced with the empty string if Bikeshed can’t find a definition.)</p>
    <h4 class="heading settled" data-level="5.11.1" id="including-code"><span class="secno">5.11.1. </span><span class="content">Including Code Files</span><a class="self-link" href="#including-code"></a></h4>
    <p>While it’s easy to include short code snippets in your document inline
@@ -4475,7 +4479,7 @@ into a larger outer document.
 But what if you want to include some markup
 that isn’t formatted as Bikeshed code?
 For example, SVG outputted by a design tool
-might not conform to Bikeshed’s syntax—​it might not indent properly,
+might not conform to Bikeshed’s syntax—<wbr>it might not indent properly,
 or it might use markup that will get messed up if parsed as Markdown,
 etc.</p>
    <p>To avoid this,
@@ -4558,7 +4562,7 @@ Bikeshed will assume you know what you’re doing,
 skip detection,
 and leave the element unchanged.</p>
    <p>To opt out of this automated size detection for a single image,
-set the boolean <dfn class="dfn-paneled" data-dfn-for="img" data-dfn-type="element-attr" data-export id="element-attrdef-img-no-autosize"><code>no-autosize</code></dfn> attribute on it.
+set the boolean <dfn data-dfn-for="img" data-dfn-type="element-attr" data-export id="element-attrdef-img-no-autosize"><code>no-autosize</code><a class="self-link" href="#element-attrdef-img-no-autosize"></a></dfn> attribute on it.
 To opt out for the entire document,
 specify the <a data-link-type="dfn" href="#metadata-image-auto-size" id="ref-for-metadata-image-auto-size">Image Auto Size</a> metadata with the value false.</p>
    <h2 class="heading settled" data-level="6" id="definitions"><span class="secno">6. </span><span class="content">Definitions</span><a class="self-link" href="#definitions"></a></h2>
@@ -5206,7 +5210,7 @@ some of which are optional.
 For example,
 if you don’t specify a <code>for</code> value,
 then Bikeshed simply doesn’t care about the <code>for</code> values of definitions as it searches.
-However, this doesn’t always match people’s mental models—​in particular, people sometimes implicitly assume that an autolink without a <code>for</code> will specifically match a <em>definition</em> without a <code>for</code>.</p>
+However, this doesn’t always match people’s mental models—<wbr>in particular, people sometimes implicitly assume that an autolink without a <code>for</code> will specifically match a <em>definition</em> without a <code>for</code>.</p>
    <p>Usually this is fine;
 if there are multiple possible definitions,
 Bikeshed will just throw up a linking error
@@ -5399,7 +5403,7 @@ Initial: auto
 Inherited: no
 Applies to: <c- p>&lt;</c-><c- f>a</c-><c- p>></c->flex items<c- p>&lt;/</c-><c- f>a</c-><c- p>></c->
 Computed value: as specified, with lengths made absolute
-Percentages: relative to the <c- p>&lt;</c-><c- f>a</c-><c- p>></c->flex container's<c- p>&lt;/</c-><c- f>a</c-><c- p>></c-> inner <c- p>&lt;</c-><c- f>a</c-><c- p>></c->main size<c- p>&lt;/</c-><c- f>a</c-><c- p>></c->
+Percentages: relative to the <c- p>&lt;</c-><c- f>a</c-><c- p>></c->flex container’s<c- p>&lt;/</c-><c- f>a</c-><c- p>></c-> inner <c- p>&lt;</c-><c- f>a</c-><c- p>></c->main size<c- p>&lt;/</c-><c- f>a</c-><c- p>></c->
 Animation type: length
 Canonical Order: per grammar
 <c- p>&lt;/</c-><c- f>pre</c-><c- p>></c->
@@ -5524,10 +5528,10 @@ they’re placed after all the built-in keys.</p>
     <tbody>
      <tr>
       <th>Name:
-      <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export id="propdef-flex-basis">flex-basis</dfn>
+      <td><dfn class="css" data-dfn-type="property" data-export id="propdef-flex-basis">flex-basis<a class="self-link" href="#propdef-flex-basis"></a></dfn>
      <tr class="value">
       <th><a href="https://www.w3.org/TR/css-values/#value-defs">Value:</a>
-      <td class="prod">content | &lt;&lt;'width'>>
+      <td class="prod">content | <a class="production css" data-link-type="property" href="https://drafts.csswg.org/css-sizing-3/#propdef-width" id="ref-for-propdef-width">&lt;'width'></a>
      <tr>
       <th><a href="https://www.w3.org/TR/css-cascade/#initial-values">Initial:</a>
       <td>auto
@@ -5600,7 +5604,7 @@ This is freeform HTML.</p>
 A comma-separated list of attribute names
 and/or attribute groups
 that this element can have.
-These will be automatically be wrapped in links for you—​<code>element-attr</code> type for attributes,
+These will be automatically be wrapped in links for you—<wbr><code>element-attr</code> type for attributes,
 and <code>dfn</code> type for attribute groups
 (like "core attributes" in SVG).</p>
     <li data-md>
@@ -5621,7 +5625,7 @@ they’re placed after all the built-in keys.</p>
 <c- p>&lt;/</c-><c- f>pre</c-><c- p>></c->
 
 <c- p>&lt;</c-><c- f>pre</c-> <c- e>class</c-><c- o>=</c-><c- s>argumentdef</c-> <c- e>for</c-><c- o>=</c-><c- s>"Foo/bar()"</c-><c- p>></c->
-arg1: here's the first arg
+arg1: here’s the first arg
 arg2: the second arg is different!
 <c- p>&lt;/</c-><c- f>pre</c-><c- p>></c->
 </pre>
@@ -5637,8 +5641,8 @@ its description,
 and automatically contain its type, nullability, and optionality
 (determined from the IDL block),
 like:</p>
-<pre class="idl highlight def" style="display:none"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="foo"><code><c- g>Foo</c-></code></dfn> {
-  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined"><c- b>undefined</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Foo" data-dfn-type="method" data-export data-lt="bar(arg1, arg2)" id="dom-foo-bar"><code><c- g>bar</c-></code></dfn>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-long" id="ref-for-idl-long"><c- b>long</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Foo/bar(arg1, arg2)" data-dfn-type="argument" data-export id="dom-foo-bar-arg1-arg2-arg1"><code><c- g>arg1</c-></code></dfn>, <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a>? <dfn class="dfn-paneled idl-code" data-dfn-for="Foo/bar(arg1, arg2)" data-dfn-type="argument" data-export id="dom-foo-bar-arg1-arg2-arg2"><code><c- g>arg2</c-></code></dfn>);
+<pre class="idl highlight def" style="display:none"><c- b>interface</c-> <dfn class="idl-code" data-dfn-type="interface" data-export id="foo"><code><c- g>Foo</c-></code><a class="self-link" href="#foo"></a></dfn> {
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined"><c- b>undefined</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Foo" data-dfn-type="method" data-export data-lt="bar(arg1, arg2)" id="dom-foo-bar"><code><c- g>bar</c-></code></dfn>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-long" id="ref-for-idl-long"><c- b>long</c-></a> <dfn class="idl-code" data-dfn-for="Foo/bar(arg1, arg2)" data-dfn-type="argument" data-export id="dom-foo-bar-arg1-arg2-arg1"><code><c- g>arg1</c-></code><a class="self-link" href="#dom-foo-bar-arg1-arg2-arg1"></a></dfn>, <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a>? <dfn class="idl-code" data-dfn-for="Foo/bar(arg1, arg2)" data-dfn-type="argument" data-export id="dom-foo-bar-arg1-arg2-arg2"><code><c- g>arg2</c-></code><a class="self-link" href="#dom-foo-bar-arg1-arg2-arg2"></a></dfn>);
 };
 </pre>
    <table class="argumentdef data">
@@ -5652,13 +5656,13 @@ like:</p>
       <th>Description
     <tbody>
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="Foo/bar()" data-dfn-type="argument" data-export id="dom-foo-bar-arg1"><code>arg1</code></dfn>
+      <td><dfn class="idl-code" data-dfn-for="Foo/bar()" data-dfn-type="argument" data-export id="dom-foo-bar-arg1"><code>arg1</code><a class="self-link" href="#dom-foo-bar-arg1"></a></dfn>
       <td><code class="idl"><a data-link-type="idl-name" href="https://webidl.spec.whatwg.org/#idl-long" id="ref-for-idl-long①">long</a></code>
       <td style="text-align:center"><span class="no">✘</span>
       <td style="text-align:center"><span class="no">✘</span>
       <td>here’s the first arg
      <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="Foo/bar()" data-dfn-type="argument" data-export id="dom-foo-bar-arg2"><code>arg2</code></dfn>
+      <td><dfn class="idl-code" data-dfn-for="Foo/bar()" data-dfn-type="argument" data-export id="dom-foo-bar-arg2"><code>arg2</code><a class="self-link" href="#dom-foo-bar-arg2"></a></dfn>
       <td><code class="idl"><a data-link-type="idl-name" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString①">DOMString</a>?</code>
       <td style="text-align:center"><span class="yes">✔</span>
       <td style="text-align:center"><span class="no">✘</span>
@@ -5873,7 +5877,7 @@ so you’ll be alerted when new tests are added.</p>
 (or <em>no longer</em> exists due to tests being moved or deleted),
 it will trigger a fatal error.</p>
      <p>This check can be disabled for a given <code><a data-link-type="element" href="#wpt-element" id="ref-for-wpt-element⑨">wpt</a></code> element
-by giving it the <dfn class="dfn-paneled idl-code" data-dfn-for="wpt" data-dfn-type="attribute" data-export id="dom-wpt-skip-existence-check"><code>skip-existence-check</code></dfn> boolean attribute.
+by giving it the <dfn class="idl-code" data-dfn-for="wpt" data-dfn-type="attribute" data-export id="dom-wpt-skip-existence-check"><code>skip-existence-check</code><a class="self-link" href="#dom-wpt-skip-existence-check"></a></dfn> boolean attribute.
 This allows you to point to private tests,
 such as those in browser-specific repos,
 without receiving errors about those tests missing
@@ -6045,58 +6049,61 @@ Note that this is similar to the syntax for bibliography references, but it has 
 The following macros are defined:</p>
    <ul>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-title"><code>[TITLE]</code></dfn> gives the spec’s full title, as extracted from either the H1 or the spec metadata.</p>
+     <p><dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-bikeshed-documentation"><code>Bikeshed Documentation</code><a class="self-link" href="#macro-bikeshed-documentation"></a></dfn> gives the spec’s full title, as extracted from either the H1 or the spec metadata.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-h1"><code>[H1]</code></dfn> gives the desired document heading, in case the in-page title is supposed to be different from the <code>&lt;title></code> element value.</p>
+     <p><dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-h1"><code>[H1]</code><a class="self-link" href="#macro-h1"></a></dfn> gives the desired document heading, in case the in-page title is supposed to be different from the <code>&lt;title></code> element value.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-shortname"><code>[SHORTNAME]</code></dfn> gives the document’s shortname, like "css-cascade".</p>
+     <p><dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-bikeshed"><code>bikeshed</code><a class="self-link" href="#macro-bikeshed"></a></dfn> gives the document’s shortname, like "css-cascade".</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-vshortname"><code>[VSHORTNAME]</code></dfn> gives the "versioned" shortname, like "css-cascade-3".</p>
+     <p><dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-bikeshed-1"><code>bikeshed-1</code><a class="self-link" href="#macro-bikeshed-1"></a></dfn> gives the "versioned" shortname, like "css-cascade-3".</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-status"><code>[STATUS]</code></dfn> gives the spec’s status.</p>
+     <p><dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-ls"><code>LS</code><a class="self-link" href="#macro-ls"></a></dfn> gives the spec’s status.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-longstatus"><code>[LONGSTATUS]</code></dfn> gives a long form of the spec’s status, so "ED" becomes "Editor’s Draft", for example.</p>
+     <p><dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-living-standard"><code>Living Standard</code><a class="self-link" href="#macro-living-standard"></a></dfn> gives a long form of the spec’s status, so "ED" becomes "Editor’s Draft", for example.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-statustext"><code>[STATUSTEXT]</code></dfn> gives an additional status text snippet.</p>
+     <p><dfn><code></code></dfn> gives an additional status text snippet.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-latest"><code>[LATEST]</code></dfn> gives the link to the undated /TR link, if it exists.</p>
+     <p><dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-latest"><code>[LATEST]</code><a class="self-link" href="#macro-latest"></a></dfn> gives the link to the undated /TR link, if it exists.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-version"><code>[VERSION]</code></dfn> gives the link to the ED, if the spec is an ED, and otherwise constructs a dated /TR link from today’s date.</p>
+     <p><dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-https-specedgithubio-bikeshed"><code>https://speced.github.io/bikeshed/</code><a class="self-link" href="#macro-https-specedgithubio-bikeshed"></a></dfn> gives the link to the ED, if the spec is an ED, and otherwise constructs a dated /TR link from today’s date.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-abstract"><code>[ABSTRACT]</code></dfn> gives the document’s abstract.</p>
+     <p><dfn><code></code></dfn></p>
+     <p><code>Bikeshed is a spec-generating tool that takes in lightly-decorated Markdown and spits out a full spec, with cross-spec autolinking, automatic generation of indexes/ToC/etc, and many other features.</code></p>
+     <code> </code> gives the document’s abstract.
+     <p></p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-abstractattr"><code>[ABSTRACTATTR]</code></dfn> gives the document’s abstract, correctly escaped to be an attribute value.</p>
+     <p><dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-abstractattr"><code>[ABSTRACTATTR]</code><a class="self-link" href="#macro-abstractattr"></a></dfn> gives the document’s abstract, correctly escaped to be an attribute value.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-year"><code>[YEAR]</code></dfn> gives the current year.</p>
+     <p><dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-2024"><code>2024</code><a class="self-link" href="#macro-2024"></a></dfn> gives the current year.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-date"><code>[DATE]</code></dfn> or <dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-date-dmmy"><code>[DATE-DMMY]</code></dfn> gives a human-readable date like "30 January 2000".</p>
+     <p><dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-13-january-2024"><code>13 January 2024</code><a class="self-link" href="#macro-13-january-2024"></a></dfn> or <dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-13-january-2024①"><code>13 January 2024</code><a class="self-link" href="#macro-13-january-2024①"></a></dfn> gives a human-readable date like "30 January 2000".</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-date-my"><code>[DATE-MY]</code></dfn> gives a partial date like "Jan 2000"</p>
+     <p><dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-jan-2024"><code>Jan 2024</code><a class="self-link" href="#macro-jan-2024"></a></dfn> gives a partial date like "Jan 2000"</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-date-mmy"><code>[DATE-MMY]</code></dfn> gives a partial date like "January 2000"</p>
+     <p><dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-january-2024"><code>January 2024</code><a class="self-link" href="#macro-january-2024"></a></dfn> gives a partial date like "January 2000"</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-cdate"><code>[CDATE]</code></dfn> gives a compact date in the format "YYYYMMDD", like "20000130"</p>
+     <p><dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-20240113"><code>20240113</code><a class="self-link" href="#macro-20240113"></a></dfn> gives a compact date in the format "YYYYMMDD", like "20000130"</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-isodate"><code>[ISODATE]</code></dfn> gives a compact date in iso format "YYYY-MM-DD", like "2000-01-30"</p>
+     <p><dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-2024-01-13"><code>2024-01-13</code><a class="self-link" href="#macro-2024-01-13"></a></dfn> gives a compact date in iso format "YYYY-MM-DD", like "2000-01-30"</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-deadline"><code>[DEADLINE]</code></dfn> gives a human-readable version of the deadline date (formatted like <a data-link-type="dfn" href="#macro-date" id="ref-for-macro-date">[DATE]</a>), if one was specified.</p>
+     <p><dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-deadline"><code>[DEADLINE]</code><a class="self-link" href="#macro-deadline"></a></dfn> gives a human-readable version of the deadline date (formatted like <a data-link-type="dfn">[DATE]</a>), if one was specified.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-logo"><code>[LOGO]</code></dfn> gives the url of the spec’s logo.</p>
+     <p><dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-logo"><code>[LOGO]</code><a class="self-link" href="#macro-logo"></a></dfn> gives the url of the spec’s logo.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-repository"><code>[REPOSITORY]</code></dfn> gives the name of the VCS repository the spec is located in;
+     <p><dfn data-dfn-for="macro" data-dfn-type="dfn" data-export id="macro-speced-bikeshed"><code>speced/bikeshed</code><a class="self-link" href="#macro-speced-bikeshed"></a></dfn> gives the name of the VCS repository the spec is located in;
 this is currently only filled when the spec source is in a GitHub repository.
 (Patches welcome for more repo-extraction code!)</p>
    </ul>
    <p>As these are substituted at the text level, not the higher HTML level, you can use them <em>anywhere</em>, including in attribute values.</p>
    <p>You can mark a macro as "optional" by appending a <code>?</code> to its name,
-like <code>[DATE?]</code>.
+like <code>13 January 2024</code>.
 This will cause Bikeshed to just remove it
 (replace it with the empty string)
 if it can’t find a definition,
 rather than throwing an error.</p>
    <p>Like most other markup shorthands,
 text macros can be "escaped" by prepending a backslash,
-like <code>\[TITLE]</code>.
+like <code>[TITLE]</code>.
 When Bikeshed sees this,
 it will remove the slash and leave the text alone.
 This is sometimes necessary when code examples in your doc (such as a regex)
@@ -6133,7 +6140,7 @@ so you can include text that uses a custom text macro only if that macro is defi
 If you’re conditioning an element on the existence of a text macro
 so you can use that macro only when it is defined,
 make sure the text macro is marked as <em>optional</em> when you use it
-(written as <code>[FOO?]</code> rather than just <code>[FOO]</code>),
+(written as <code></code> rather than just <code>[FOO]</code>),
 so it doesn’t trigger an "unknown text macro" error
 before throwing away the element anyway.</p>
     <li data-md>
@@ -6279,7 +6286,7 @@ and all specs in the same organization can look similar.</p>
 <c- p>&lt;</c-><c- f>html</c-> <c- e>lang</c-><c- o>=</c-><c- s>"en"</c-><c- p>></c->
 <c- p>&lt;</c-><c- f>head</c-><c- p>></c->
   <c- p>&lt;</c-><c- f>meta</c-> <c- e>http-equiv</c-><c- o>=</c-><c- s>"Content-Type"</c-> <c- e>content</c-><c- o>=</c-><c- s>"text/html; charset=utf-8"</c-><c- p>></c->
-  <c- p>&lt;</c-><c- f>title</c-><c- p>></c->[TITLE]<c- p>&lt;/</c-><c- f>title</c-><c- p>></c->
+  <c- p>&lt;</c-><c- f>title</c-><c- p>></c->Bikeshed Documentation<c- p>&lt;/</c-><c- f>title</c-><c- p>></c->
   <c- p>&lt;</c-><c- f>style</c-><c- p>></c->
   <c- o>...</c->
   <c- p>&lt;/</c-><c- f>style</c-><c- p>></c->
@@ -6287,9 +6294,9 @@ and all specs in the same organization can look similar.</p>
 <c- p>&lt;</c-><c- f>body</c-> <c- e>class</c-><c- o>=</c-><c- s>"h-entry"</c-><c- p>></c->
 <c- p>&lt;</c-><c- f>div</c-> <c- e>class</c-><c- o>=</c-><c- s>"head"</c-><c- p>></c->
   <c- p>&lt;</c-><c- f>p</c-> <c- e>data-fill-with</c-><c- o>=</c-><c- s>"logo"</c-><c- p>>&lt;/</c-><c- f>p</c-><c- p>></c->
-  <c- p>&lt;</c-><c- f>h1</c-> <c- e>id</c-><c- o>=</c-><c- s>"title"</c-> <c- e>class</c-><c- o>=</c-><c- s>"p-name no-ref"</c-><c- p>></c->[TITLE]<c- p>&lt;/</c-><c- f>h1</c-><c- p>></c->
-  <c- p>&lt;</c-><c- f>h2</c-> <c- e>id</c-><c- o>=</c-><c- s>"subtitle"</c-> <c- e>class</c-><c- o>=</c-><c- s>"no-num no-toc no-ref"</c-><c- p>></c->[LONGSTATUS],
-    <c- p>&lt;</c-><c- f>span</c-> <c- e>class</c-><c- o>=</c-><c- s>"dt-updated"</c-><c- p>>&lt;</c-><c- f>span</c-> <c- e>class</c-><c- o>=</c-><c- s>"value-title"</c-> <c- e>title</c-><c- o>=</c-><c- s>"[CDATE]"</c-><c- p>></c->[DATE]<c- p>&lt;/</c-><c- f>span</c-><c- p>></c->
+  <c- p>&lt;</c-><c- f>h1</c-> <c- e>id</c-><c- o>=</c-><c- s>"title"</c-> <c- e>class</c-><c- o>=</c-><c- s>"p-name no-ref"</c-><c- p>></c->Bikeshed Documentation<c- p>&lt;/</c-><c- f>h1</c-><c- p>></c->
+  <c- p>&lt;</c-><c- f>h2</c-> <c- e>id</c-><c- o>=</c-><c- s>"subtitle"</c-> <c- e>class</c-><c- o>=</c-><c- s>"no-num no-toc no-ref"</c-><c- p>></c->Living Standard,
+    <c- p>&lt;</c-><c- f>span</c-> <c- e>class</c-><c- o>=</c-><c- s>"dt-updated"</c-><c- p>>&lt;</c-><c- f>span</c-> <c- e>class</c-><c- o>=</c-><c- s>"value-title"</c-> <c- e>title</c-><c- o>=</c-><c- s>"20240113"</c-><c- p>></c->13 January 2024<c- p>&lt;/</c-><c- f>span</c-><c- p>></c->
   <c- p>&lt;/</c-><c- f>h2</c-><c- p>></c->
   <c- p>&lt;</c-><c- f>div</c-> <c- e>data-fill-with</c-><c- o>=</c-><c- s>"spec-metadata"</c-><c- p>>&lt;/</c-><c- f>div</c-><c- p>></c->
   <c- p>&lt;</c-><c- f>div</c-> <c- e>data-fill-with</c-><c- o>=</c-><c- s>"warning"</c-><c- p>>&lt;/</c-><c- f>div</c-><c- p>></c->
@@ -6308,7 +6315,7 @@ and all specs in the same organization can look similar.</p>
     <li data-md>
      <p>Text replacement, via the <code>[FOO]</code> macros.
 These macros are prepopulated by Bikeshed,
-either from metadata in the spec (like <code>[TITLE]</code>) or from environment data (like <code>[DATE]</code>).
+either from metadata in the spec (like <code>Bikeshed Documentation</code>) or from environment data (like <code>13 January 2024</code>).
 The full list of text macros can be found at <a href="#text-macros">§ 12.3 Text Macros</a>.</p>
     <li data-md>
      <p>Boilerplate pieces, via empty container elements with <code>data-fill-with</code> attributes.
@@ -6506,30 +6513,30 @@ Elements are split into two groups: containers and text.</p>
    <ul>
     <ul>
      <li data-md>
-      <p><dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-sequence">Sequence</dfn> (<dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-and">And</dfn>, <dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-seq">Seq</dfn>) - used for sequences of elements which must all be selected in order.  Like concatenation in regexes. Takes 1 or more children.</p>
+      <p><dfn data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-sequence">Sequence<a class="self-link" href="#railroad-sequence"></a></dfn> (<dfn data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-and">And<a class="self-link" href="#railroad-and"></a></dfn>, <dfn data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-seq">Seq<a class="self-link" href="#railroad-seq"></a></dfn>) - used for sequences of elements which must all be selected in order.  Like concatenation in regexes. Takes 1 or more children.</p>
      <li data-md>
-      <p><dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-stack">Stack</dfn> - A sequence that arranges its children vertically. Useful for preventing diagrams from becoming excessively wide. Takes 1 or more children.</p>
+      <p><dfn data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-stack">Stack<a class="self-link" href="#railroad-stack"></a></dfn> - A sequence that arranges its children vertically. Useful for preventing diagrams from becoming excessively wide. Takes 1 or more children.</p>
      <li data-md>
-      <p><dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-choice">Choice</dfn> (<dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-or">Or</dfn>) - used for a choice between elements.  Like the <code>|</code> character in regexes.  Takes 1 or more children.  Optionally, the "default" index may be provided in the prelude (defaulting to 0).</p>
+      <p><dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-choice">Choice</dfn> (<dfn data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-or">Or<a class="self-link" href="#railroad-or"></a></dfn>) - used for a choice between elements.  Like the <code>|</code> character in regexes.  Takes 1 or more children.  Optionally, the "default" index may be provided in the prelude (defaulting to 0).</p>
      <li data-md>
-      <p><dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-optional">Optional</dfn> (<dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-opt">Opt</dfn>)- used for an element that’s optional.  Like the <code>?</code> character in regexes.  Takes 1 child.  Optionally, the word <code>skip</code> may be provided in the prelude to indicate that this term is skipped by default.</p>
+      <p><dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-optional">Optional</dfn> (<dfn data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-opt">Opt<a class="self-link" href="#railroad-opt"></a></dfn>)- used for an element that’s optional.  Like the <code>?</code> character in regexes.  Takes 1 child.  Optionally, the word <code>skip</code> may be provided in the prelude to indicate that this term is skipped by default.</p>
      <li data-md>
-      <p><dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-oneormore">OneOrMore</dfn> (<dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-plus">Plus</dfn>)- used for an element that can be chosen one or more times.  Like the <code>+</code> character in regexes.
+      <p><dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-oneormore">OneOrMore</dfn> (<dfn data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-plus">Plus<a class="self-link" href="#railroad-plus"></a></dfn>)- used for an element that can be chosen one or more times.  Like the <code>+</code> character in regexes.
 Takes 1 or 2 children: the first child is the element being repeated, and the optional second child is an element repeated between repetitions.</p>
      <li data-md>
-      <p><dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-zeroormore">ZeroOrMore</dfn> (<dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-star">Star</dfn>) - same as <a data-link-type="dfn" href="#railroad-oneormore" id="ref-for-railroad-oneormore">OneOrMore</a>, but allows the element to be chosen zero times as well (skipped entirely).  Like the <code>*</code> character in regexes.
+      <p><dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-zeroormore">ZeroOrMore</dfn> (<dfn data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-star">Star<a class="self-link" href="#railroad-star"></a></dfn>) - same as <a data-link-type="dfn" href="#railroad-oneormore" id="ref-for-railroad-oneormore">OneOrMore</a>, but allows the element to be chosen zero times as well (skipped entirely).  Like the <code>*</code> character in regexes.
 Like <a data-link-type="dfn" href="#railroad-optional" id="ref-for-railroad-optional">Optional</a>, the keyword <code>skip</code> may be provided in the prelude to indicate that the "default option" is to skip it (repeat 0 times).</p>
     </ul>
     <p>The text elements only contain text, not other elements.  Their values are given in their preludes.</p>
     <ul>
      <li data-md>
-      <p><dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-terminal">Terminal</dfn> (<dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-t">T</dfn>) - represents a "terminal" in the grammar, something that can’t be expanded any more.  Generally represents literal text.</p>
+      <p><dfn data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-terminal">Terminal<a class="self-link" href="#railroad-terminal"></a></dfn> (<dfn data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-t">T<a class="self-link" href="#railroad-t"></a></dfn>) - represents a "terminal" in the grammar, something that can’t be expanded any more.  Generally represents literal text.</p>
      <li data-md>
-      <p><dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-nonterminal">NonTerminal</dfn> (<dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-n">N</dfn>) - represents a "non-terminal" in the grammar, something that can be expanded further.</p>
+      <p><dfn data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-nonterminal">NonTerminal<a class="self-link" href="#railroad-nonterminal"></a></dfn> (<dfn data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-n">N<a class="self-link" href="#railroad-n"></a></dfn>) - represents a "non-terminal" in the grammar, something that can be expanded further.</p>
      <li data-md>
-      <p><dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-comment">Comment</dfn> (<dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-c">C</dfn>) - represents a comment in the railroad diagram, to aid in reading or provide additional information.  This is often used as the repetition value of a <a data-link-type="dfn" href="#railroad-oneormore" id="ref-for-railroad-oneormore①">OneOrMore</a> or <a data-link-type="dfn" href="#railroad-zeroormore" id="ref-for-railroad-zeroormore">ZeroOrMore</a> to provide information about the repetitions, like how many are allowed.</p>
+      <p><dfn data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-comment">Comment<a class="self-link" href="#railroad-comment"></a></dfn> (<dfn data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-c">C<a class="self-link" href="#railroad-c"></a></dfn>) - represents a comment in the railroad diagram, to aid in reading or provide additional information.  This is often used as the repetition value of a <a data-link-type="dfn" href="#railroad-oneormore" id="ref-for-railroad-oneormore①">OneOrMore</a> or <a data-link-type="dfn" href="#railroad-zeroormore" id="ref-for-railroad-zeroormore">ZeroOrMore</a> to provide information about the repetitions, like how many are allowed.</p>
      <li data-md>
-      <p><dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-skip">Skip</dfn> (<dfn class="dfn-paneled" data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-s">S</dfn>) - represents nothing, an empty option.  This is rarely necessary to use explicitly, as containers like <a data-link-type="dfn" href="#railroad-optional" id="ref-for-railroad-optional①">Optional</a> use it automatically, but it’s occasionally useful when writing out a <a data-link-type="dfn" href="#railroad-choice" id="ref-for-railroad-choice">Choice</a> element where one option is to do nothing.</p>
+      <p><dfn data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-skip">Skip<a class="self-link" href="#railroad-skip"></a></dfn> (<dfn data-dfn-for="railroad" data-dfn-type="dfn" data-export id="railroad-s">S<a class="self-link" href="#railroad-s"></a></dfn>) - represents nothing, an empty option.  This is rarely necessary to use explicitly, as containers like <a data-link-type="dfn" href="#railroad-optional" id="ref-for-railroad-optional①">Optional</a> use it automatically, but it’s occasionally useful when writing out a <a data-link-type="dfn" href="#railroad-choice" id="ref-for-railroad-choice">Choice</a> element where one option is to do nothing.</p>
     </ul>
    </ul>
    <h2 class="heading settled" data-level="14" id="source"><span class="secno">14. </span><span class="content">Source-File Processing: <code>bikeshed source</code></span><a class="self-link" href="#source"></a></h2>
@@ -6660,7 +6667,7 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
       on = !document.body.classList.contains('toc-sidebar');
     }
 
-    /* Don't scroll to compensate for the ToC if we're above it already. */
+    /* Don’t scroll to compensate for the ToC if we’re above it already. */
     var headY = 0;
     var head = document.querySelector('.head');
     if (head) {
@@ -6691,16 +6698,16 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
       }
       if (toggle.matches(':hover')) {
         /* Unfocus button when not using keyboard navigation,
-           because I don't know where else to send the focus. */
+           because I don’t know where else to send the focus. */
         toggle.blur();
       }
     }
   }
 
   function createSidebarToggle() {
-    /* Create the sidebar toggle in JS; it shouldn't exist when JS is off. */
+    /* Create the sidebar toggle in JS; it shouldn’t exist when JS is off. */
     var toggle = document.createElement('a');
-      /* This should probably be a button, but appearance isn't standards-track.*/
+      /* This should probably be a button, but appearance isn’t standards-track.*/
     toggle.id = 'toc-toggle';
     toggle.class = 'toc-toggle';
     toggle.href = '#toc';
@@ -6716,7 +6723,7 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
     toggle.addEventListener('click', toggler, false);
 
 
-    /* Get <nav id=toc-nav>, or make it if we don't have one. */
+    /* Get <nav id=toc-nav>, or make it if we don’t have one. */
     var tocNav = document.getElementById('toc-nav');
     if (!tocNav) {
       tocNav = document.createElement('p');
@@ -6724,7 +6731,7 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
       /* Prepend for better keyboard navigation */
       document.body.insertBefore(tocNav, document.body.firstChild);
     }
-    /* While we're at it, make sure we have a Jump to Toc link. */
+    /* While we’re at it, make sure we have a Jump to Toc link. */
     var tocJump = document.getElementById('toc-jump');
     if (!tocJump) {
       tocJump = document.createElement('a');
@@ -6752,7 +6759,7 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
     }, false);
   }
   else {
-    console.warn("Can't find Table of Contents. Please use <nav id='toc'> around the ToC.");
+    console.warn("Can’t find Table of Contents. Please use <nav id='toc'> around the ToC.");
   }
 
   /* Wrap tables in case they overflow */
@@ -6771,7 +6778,15 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#macro-abstract">[ABSTRACT]</a><span>, in § 12.3</span>
+   <li>
+    13 January 2024
+    <ul>
+     <li><a href="#macro-13-january-2024">dfn for macro</a><span>, in § 12.3</span>
+     <li><a href="#macro-13-january-2024①">dfn for macro</a><span>, in § 12.3</span>
+    </ul>
+   <li><a href="#macro-2024">2024</a><span>, in § 12.3</span>
+   <li><a href="#macro-2024-01-13">2024-01-13</a><span>, in § 12.3</span>
+   <li><a href="#macro-20240113">20240113</a><span>, in § 12.3</span>
    <li><a href="#metadata-abstract">Abstract</a><span>, in § 4</span>
    <li><a href="#macro-abstractattr">[ABSTRACTATTR]</a><span>, in § 12.3</span>
    <li><a href="#metadata-advisement-class">Advisement Class</a><span>, in § 4</span>
@@ -6782,24 +6797,22 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
    <li><a href="#metadata-at-risk">At Risk</a><span>, in § 4</span>
    <li><a href="#dom-foo-bar">bar(arg1, arg2)</a><span>, in § 9.5</span>
    <li><a href="#biblio-autolink">biblio autolink</a><span>, in § 7.2</span>
+   <li><a href="#macro-bikeshed">bikeshed</a><span>, in § 12.3</span>
+   <li><a href="#macro-bikeshed-1">bikeshed-1</a><span>, in § 12.3</span>
+   <li><a href="#macro-bikeshed-documentation">Bikeshed Documentation</a><span>, in § 12.3</span>
    <li><a href="#metadata-block-elements">Block Elements</a><span>, in § 4</span>
    <li><a href="#metadata-boilerplate">Boilerplate</a><span>, in § 4</span>
    <li><a href="#boolish">boolish</a><span>, in § 4</span>
    <li><a href="#railroad-c">C</a><span>, in § 13.1</span>
    <li><a href="#metadata-can-i-use-url">Can I Use URL</a><span>, in § 4</span>
    <li><a href="#metadata-canonical-url">Canonical URL</a><span>, in § 4</span>
-   <li><a href="#macro-cdate">[CDATE]</a><span>, in § 12.3</span>
    <li><a href="#railroad-choice">Choice</a><span>, in § 13.1</span>
    <li><a href="#railroad-comment">Comment</a><span>, in § 13.1</span>
    <li><a href="#metadata-complain-about">Complain About</a><span>, in § 4</span>
    <li><a href="#metadata-custom-warning-text">Custom Warning Text</a><span>, in § 4</span>
    <li><a href="#metadata-custom-warning-title">Custom Warning Title</a><span>, in § 4</span>
    <li><a href="#metadata-dark-mode">Dark Mode</a><span>, in § 4</span>
-   <li><a href="#macro-date">[DATE]</a><span>, in § 12.3</span>
    <li><a href="#metadata-date">Date</a><span>, in § 4</span>
-   <li><a href="#macro-date-dmmy">[DATE-DMMY]</a><span>, in § 12.3</span>
-   <li><a href="#macro-date-mmy">[DATE-MMY]</a><span>, in § 12.3</span>
-   <li><a href="#macro-date-my">[DATE-MY]</a><span>, in § 12.3</span>
    <li><a href="#macro-deadline">[DEADLINE]</a><span>, in § 12.3</span>
    <li><a href="#metadata-deadline">Deadline</a><span>, in § 4</span>
    <li><a href="#metadata-default-biblio-display">Default Biblio Display</a><span>, in § 4</span>
@@ -6822,12 +6835,14 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
    <li><a href="#metadata-group">Group</a><span>, in § 4</span>
    <li><a href="#macro-h1">[H1]</a><span>, in § 12.3</span>
    <li><a href="#metadata-h1">H1</a><span>, in § 4</span>
+   <li><a href="#macro-https-specedgithubio-bikeshed">https://speced.github.io/bikeshed/</a><span>, in § 12.3</span>
    <li><a href="#elementdef-if-wrapper">if-wrapper</a><span>, in § 12.4</span>
    <li><a href="#metadata-ignore-can-i-use-url-failure">Ignore Can I Use URL Failure</a><span>, in § 4</span>
    <li><a href="#metadata-ignored-terms">Ignored Terms</a><span>, in § 4</span>
    <li><a href="#metadata-ignored-vars">Ignored Vars</a><span>, in § 4</span>
    <li><a href="#metadata-ignore-mdn-failure">Ignore MDN Failure</a><span>, in § 4</span>
    <li><a href="#metadata-image-auto-size">Image Auto Size</a><span>, in § 4</span>
+   <li><a href="#metadata-implementation-report">Implementation Report</a><span>, in § 4</span>
    <li><a href="#metadata-include-can-i-use-panels">Include Can I Use Panels</a><span>, in § 4</span>
    <li><a href="#element-attrdef-global-include-if">include-if</a><span>, in § 12.4</span>
    <li><a href="#metadata-include-mdn-panels">Include MDN Panels</a><span>, in § 4</span>
@@ -6835,19 +6850,21 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
    <li><a href="#metadata-infer-css-dfns">Infer CSS Dfns</a><span>, in § 4</span>
    <li><a href="#metadata-informative-classes">Informative Classes</a><span>, in § 4</span>
    <li><a href="#metadata-inline-github-issues">Inline Github Issues</a><span>, in § 4</span>
-   <li><a href="#macro-isodate">[ISODATE]</a><span>, in § 12.3</span>
    <li><a href="#metadata-issue-class">Issue Class</a><span>, in § 4</span>
    <li><a href="#metadata-issue-tracker-template">Issue Tracker Template</a><span>, in § 4</span>
    <li><a href="#metadata-issue-tracking">Issue Tracking</a><span>, in § 4</span>
+   <li><a href="#macro-jan-2024">Jan 2024</a><span>, in § 12.3</span>
+   <li><a href="#macro-january-2024">January 2024</a><span>, in § 12.3</span>
    <li><a href="#l-element">l</a><span>, in § 5.4</span>
    <li><a href="#macro-latest">[LATEST]</a><span>, in § 12.3</span>
    <li><a href="#metadata-level">Level</a><span>, in § 4</span>
    <li><a href="#metadata-line-numbers">Line Numbers</a><span>, in § 4</span>
    <li><a href="#metadata-link-defaults">Link Defaults</a><span>, in § 4</span>
+   <li><a href="#macro-living-standard">Living Standard</a><span>, in § 12.3</span>
    <li><a href="#metadata-local-boilerplate">Local Boilerplate</a><span>, in § 4</span>
    <li><a href="#macro-logo">[LOGO]</a><span>, in § 12.3</span>
    <li><a href="#metadata-logo">Logo</a><span>, in § 4</span>
-   <li><a href="#macro-longstatus">[LONGSTATUS]</a><span>, in § 12.3</span>
+   <li><a href="#macro-ls">LS</a><span>, in § 12.3</span>
    <li><a href="#metadata-mailing-list">Mailing List</a><span>, in § 4</span>
    <li><a href="#metadata-mailing-list-archives">Mailing List Archives</a><span>, in § 4</span>
    <li><a href="#manual-autolink">manual autolink</a><span>, in § 7.3</span>
@@ -6871,30 +6888,26 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
    <li><a href="#metadata-prepare-for-tr">Prepare For TR</a><span>, in § 4</span>
    <li><a href="#metadata-previous-version">Previous Version</a><span>, in § 4</span>
    <li><a href="#metadata-remove-multiple-links">Remove Multiple Links</a><span>, in § 4</span>
-   <li><a href="#macro-repository">[REPOSITORY]</a><span>, in § 12.3</span>
    <li><a href="#metadata-repository">Repository</a><span>, in § 4</span>
    <li><a href="#metadata-required-ids">Required IDs</a><span>, in § 4</span>
    <li><a href="#metadata-revision">Revision</a><span>, in § 4</span>
    <li><a href="#railroad-s">S</a><span>, in § 13.1</span>
    <li><a href="#railroad-seq">Seq</a><span>, in § 13.1</span>
    <li><a href="#railroad-sequence">Sequence</a><span>, in § 13.1</span>
-   <li><a href="#macro-shortname">[SHORTNAME]</a><span>, in § 12.3</span>
    <li><a href="#metadata-shortname">Shortname</a><span>, in § 4</span>
    <li><a href="#railroad-skip">Skip</a><span>, in § 13.1</span>
    <li><a href="#dom-wpt-skip-existence-check">skip-existence-check</a><span>, in § 11.1</span>
    <li><a href="#metadata-slim-build-artifact">Slim Build Artifact</a><span>, in § 4</span>
    <li><a href="#soft-boolish">soft boolish</a><span>, in § 4</span>
+   <li><a href="#macro-speced-bikeshed">speced/bikeshed</a><span>, in § 12.3</span>
    <li><a href="#railroad-stack">Stack</a><span>, in § 13.1</span>
    <li><a href="#railroad-star">Star</a><span>, in § 13.1</span>
-   <li><a href="#macro-status">[STATUS]</a><span>, in § 12.3</span>
    <li><a href="#metadata-status">Status</a><span>, in § 4</span>
-   <li><a href="#macro-statustext">[STATUSTEXT]</a><span>, in § 12.3</span>
    <li><a href="#metadata-status-text">Status Text</a><span>, in § 4</span>
    <li><a href="#railroad-t">T</a><span>, in § 13.1</span>
    <li><a href="#railroad-terminal">Terminal</a><span>, in § 13.1</span>
    <li><a href="#metadata-test-suite">Test Suite</a><span>, in § 4</span>
    <li><a href="#metadata-text-macro">Text Macro</a><span>, in § 4</span>
-   <li><a href="#macro-title">[TITLE]</a><span>, in § 12.3</span>
    <li><a href="#metadata-title">Title</a><span>, in § 4</span>
    <li><a href="#metadata-toggle-diffs">Toggle Diffs</a><span>, in § 4</span>
    <li><a href="#metadata-tr">TR</a><span>, in § 4</span>
@@ -6909,15 +6922,12 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
    <li><a href="#metadata-url">URL</a><span>, in § 4</span>
    <li><a href="#metadata-use-dfn-panels">Use Dfn Panels</a><span>, in § 4</span>
    <li><a href="#metadata-use-i-autolinks">Use &lt;i> Autolinks</a><span>, in § 4</span>
-   <li><a href="#macro-version">[VERSION]</a><span>, in § 12.3</span>
-   <li><a href="#macro-vshortname">[VSHORTNAME]</a><span>, in § 12.3</span>
    <li><a href="#metadata-warning">Warning</a><span>, in § 4</span>
    <li><a href="#metadata-work-status">Work Status</a><span>, in § 4</span>
    <li><a href="#wpt-element">wpt</a><span>, in § 11</span>
    <li><a href="#metadata-wpt-display">WPT Display</a><span>, in § 4</span>
    <li><a href="#metadata-wpt-path-prefix">WPT Path Prefix</a><span>, in § 4</span>
    <li><a href="#elementdef-wpt-rest">wpt-rest</a><span>, in § 11.1</span>
-   <li><a href="#macro-year">[YEAR]</a><span>, in § 12.3</span>
    <li><a href="#railroad-zeroormore">ZeroOrMore</a><span>, in § 13.1</span>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -6933,6 +6943,11 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
     <a data-link-type="biblio">[CSS-LOGICAL-1]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="eb3aa672">logical property group</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[CSS-SIZING-3]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="88643fe0">width</span>
     </ul>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
@@ -7005,6 +7020,8 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
    <dd>Tab Atkins Jr.; et al. <a href="https://drafts.csswg.org/css-flexbox-1/"><cite>CSS Flexible Box Layout Module Level 1</cite></a>. URL: <a href="https://drafts.csswg.org/css-flexbox-1/">https://drafts.csswg.org/css-flexbox-1/</a>
    <dt id="biblio-css-logical-1">[CSS-LOGICAL-1]
    <dd>Rossen Atanassov; Elika Etemad. <a href="https://drafts.csswg.org/css-logical-1/"><cite>CSS Logical Properties and Values Level 1</cite></a>. URL: <a href="https://drafts.csswg.org/css-logical-1/">https://drafts.csswg.org/css-logical-1/</a>
+   <dt id="biblio-css-sizing-3">[CSS-SIZING-3]
+   <dd>Tab Atkins Jr.; Elika Etemad. <a href="https://drafts.csswg.org/css-sizing-3/"><cite>CSS Box Sizing Module Level 3</cite></a>. URL: <a href="https://drafts.csswg.org/css-sizing-3/">https://drafts.csswg.org/css-sizing-3/</a>
    <dt id="biblio-css-values-4">[CSS-VALUES-4]
    <dd>Tab Atkins Jr.; Elika Etemad. <a href="https://drafts.csswg.org/css-values-4/"><cite>CSS Values and Units Module Level 4</cite></a>. URL: <a href="https://drafts.csswg.org/css-values-4/">https://drafts.csswg.org/css-values-4/</a>
    <dt id="biblio-html">[HTML]
@@ -7037,7 +7054,7 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
     <tbody>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-flex-basis" id="ref-for-propdef-flex-basis">flex-basis</a>
-      <td>content | &lt;&lt;'width'>>
+      <td>content | &lt;'width'>
       <td>auto
       <td>flex items
       <td>no
@@ -7059,8 +7076,420 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
 The <code>-t</code> output is already more than enough to actually work with,
 but it would still be good to describe it more fully. <a class="issue-return" href="#issue-9f3e2897" title="Jump to section">↵</a></div>
   </div>
-<script>/* Boilerplate: script-dom-helper */
+<script>/* Boilerplate: script-dfn-panel */
 "use strict";
+{
+    const dfnsJson = window.dfnsJson || {};
+
+    function genDfnPanel({dfnID, url, dfnText, refSections, external}) {
+        return mk.aside({
+            class: "dfn-panel",
+            id: `infopanel-for-${dfnID}`,
+            "data-for": dfnID,
+            "aria-labelled-by":`infopaneltitle-for-${dfnID}`,
+            },
+            mk.span({id:`infopaneltitle-for-${dfnID}`, style:"display:none"},
+                `Info about the '${dfnText}' ${external?"external":""} reference.`),
+            mk.a({href:url}, url),
+            mk.b({}, "Referenced in:"),
+            mk.ul({},
+                ...refSections.map(section=>
+                    mk.li({},
+                        ...section.refs.map((ref, refI)=>
+                            [
+                                mk.a({
+                                    href: `#${ref.id}`
+                                    },
+                                    (refI == 0) ? section.title : `(${refI + 1})`
+                                ),
+                                " ",
+                            ]
+                        ),
+                    ),
+                ),
+            ),
+        );
+    }
+
+    function genAllDfnPanels() {
+        for(const panelData of Object.values(window.dfnpanelData)) {
+            const dfnID = panelData.dfnID;
+            const dfn = document.getElementById(dfnID);
+            if(!dfn) {
+                console.log(`Can't find dfn#${dfnID}.`, panelData);
+            } else {
+                const panel = genDfnPanel(panelData);
+                append(document.body, panel);
+                insertDfnPopupAction(dfn, panel)
+            }
+        }
+    }
+
+    document.addEventListener("DOMContentLoaded", ()=>{
+        genAllDfnPanels();
+
+        // Add popup behavior to all dfns to show the corresponding dfn-panel.
+        var dfns = queryAll('.dfn-paneled');
+        for(let dfn of dfns) { ; }
+
+        document.body.addEventListener("click", (e) => {
+            // If not handled already, just hide all dfn panels.
+            hideAllDfnPanels();
+        });
+    })
+
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn, dfnPanel) {
+        // Find dfn panel
+        const panelWrapper = document.createElement('span');
+        panelWrapper.appendChild(dfnPanel);
+        panelWrapper.style.position = "relative";
+        panelWrapper.style.height = "0px";
+        dfn.insertAdjacentElement("afterend", panelWrapper);
+        dfn.setAttribute('role', 'button');
+        dfn.setAttribute('aria-expanded', 'false')
+        dfn.tabIndex = 0;
+        dfn.classList.add('has-dfn-panel');
+        dfn.addEventListener('click', (event) => {
+            showDfnPanel(dfnPanel, dfn);
+            event.stopPropagation();
+        });
+        dfn.addEventListener('keypress', (event) => {
+            const kc = event.keyCode;
+            // 32->Space, 13->Enter
+            if(kc == 32 || kc == 13) {
+                toggleDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+                event.preventDefault();
+            }
+        });
+
+        dfnPanel.addEventListener('click', (event) => {
+            if (event.target.nodeName == 'A') {
+                pinDfnPanel(dfnPanel);
+            }
+            event.stopPropagation();
+        });
+
+        dfnPanel.addEventListener('keydown', (event) => {
+            if(event.keyCode == 27) { // Escape key
+                hideDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+                event.preventDefault();
+            }
+        })
+    }
+}
+</script>
+<script>/* Boilerplate: script-dfn-panel */
+"use strict";
+{
+    const dfnsJson = window.dfnsJson || {};
+
+    function genDfnPanel({dfnID, url, dfnText, refSections, external}) {
+        return mk.aside({
+            class: "dfn-panel",
+            id: `infopanel-for-${dfnID}`,
+            "data-for": dfnID,
+            "aria-labelled-by":`infopaneltitle-for-${dfnID}`,
+            },
+            mk.span({id:`infopaneltitle-for-${dfnID}`, style:"display:none"},
+                `Info about the '${dfnText}' ${external?"external":""} reference.`),
+            mk.a({href:url}, url),
+            mk.b({}, "Referenced in:"),
+            mk.ul({},
+                ...refSections.map(section=>
+                    mk.li({},
+                        ...section.refs.map((ref, refI)=>
+                            [
+                                mk.a({
+                                    href: `#${ref.id}`
+                                    },
+                                    (refI == 0) ? section.title : `(${refI + 1})`
+                                ),
+                                " ",
+                            ]
+                        ),
+                    ),
+                ),
+            ),
+        );
+    }
+
+    function genAllDfnPanels() {
+        for(const panelData of Object.values(window.dfnpanelData)) {
+            const dfnID = panelData.dfnID;
+            const dfn = document.getElementById(dfnID);
+            if(!dfn) {
+                console.log(`Can't find dfn#${dfnID}.`, panelData);
+            } else {
+                const panel = genDfnPanel(panelData);
+                append(document.body, panel);
+                insertDfnPopupAction(dfn, panel)
+            }
+        }
+    }
+
+    document.addEventListener("DOMContentLoaded", ()=>{
+        genAllDfnPanels();
+
+        // Add popup behavior to all dfns to show the corresponding dfn-panel.
+        var dfns = queryAll('.dfn-paneled');
+        for(let dfn of dfns) { ; }
+
+        document.body.addEventListener("click", (e) => {
+            // If not handled already, just hide all dfn panels.
+            hideAllDfnPanels();
+        });
+    })
+
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn, dfnPanel) {
+        // Find dfn panel
+        const panelWrapper = document.createElement('span');
+        panelWrapper.appendChild(dfnPanel);
+        panelWrapper.style.position = "relative";
+        panelWrapper.style.height = "0px";
+        dfn.insertAdjacentElement("afterend", panelWrapper);
+        dfn.setAttribute('role', 'button');
+        dfn.setAttribute('aria-expanded', 'false')
+        dfn.tabIndex = 0;
+        dfn.classList.add('has-dfn-panel');
+        dfn.addEventListener('click', (event) => {
+            showDfnPanel(dfnPanel, dfn);
+            event.stopPropagation();
+        });
+        dfn.addEventListener('keypress', (event) => {
+            const kc = event.keyCode;
+            // 32->Space, 13->Enter
+            if(kc == 32 || kc == 13) {
+                toggleDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+                event.preventDefault();
+            }
+        });
+
+        dfnPanel.addEventListener('click', (event) => {
+            if (event.target.nodeName == 'A') {
+                pinDfnPanel(dfnPanel);
+            }
+            event.stopPropagation();
+        });
+
+        dfnPanel.addEventListener('keydown', (event) => {
+            if(event.keyCode == 27) { // Escape key
+                hideDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+                event.preventDefault();
+            }
+        })
+    }
+}
+</script>
+<script>/* Boilerplate: script-dfn-panel-json */
+window.dfnpanelData = {};
+window.dfnpanelData['24285d87'] = {"dfnID": "24285d87", "url": "https://drafts.csswg.org/css-flexbox-1/#flex-container", "dfnText": "flex container", "refSections": [{"refs": [{"id": "ref-for-flex-container"}], "title": "9.2. CSS Property Tables"}], "external": true};
+window.dfnpanelData['66c521a7'] = {"dfnID": "66c521a7", "url": "https://drafts.csswg.org/css-flexbox-1/#flex-item", "dfnText": "flex item", "refSections": [{"refs": [{"id": "ref-for-flex-item"}], "title": "9.2. CSS Property Tables"}], "external": true};
+window.dfnpanelData['73c10739'] = {"dfnID": "73c10739", "url": "https://drafts.csswg.org/css-flexbox-1/#main-size", "dfnText": "main size", "refSections": [{"refs": [{"id": "ref-for-main-size"}], "title": "9.2. CSS Property Tables"}], "external": true};
+window.dfnpanelData['eb3aa672'] = {"dfnID": "eb3aa672", "url": "https://drafts.csswg.org/css-logical-1/#logical-property-group", "dfnText": "logical property group", "refSections": [{"refs": [{"id": "ref-for-logical-property-group"}], "title": "9.2. CSS Property Tables"}], "external": true};
+window.dfnpanelData['88643fe0'] = {"dfnID": "88643fe0", "url": "https://drafts.csswg.org/css-sizing-3/#propdef-width", "dfnText": "width", "refSections": [{"refs": [{"id": "ref-for-propdef-width"}], "title": "9.2. CSS Property Tables"}], "external": true};
+window.dfnpanelData['68bf3d31'] = {"dfnID": "68bf3d31", "url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element", "dfnText": "a", "refSections": [{"refs": [{"id": "ref-for-the-a-element"}], "title": "4. Metadata"}, {"refs": [{"id": "ref-for-the-a-element\u2460"}, {"id": "ref-for-the-a-element\u2461"}, {"id": "ref-for-the-a-element\u2462"}], "title": "5.4.1. \nAutolink Shortcuts That Work Anywhere: the l element"}, {"refs": [{"id": "ref-for-the-a-element\u2463"}], "title": "6.1. Conjugating/Pluralizing/etc the Linking Text"}, {"refs": [{"id": "ref-for-the-a-element\u2464"}, {"id": "ref-for-the-a-element\u2465"}], "title": "7. Autolinking"}, {"refs": [{"id": "ref-for-the-a-element\u2466"}, {"id": "ref-for-the-a-element\u2467"}], "title": "7.3. Manual Autolinks"}, {"refs": [{"id": "ref-for-the-a-element\u2468"}], "title": "7.4. Link Types"}, {"refs": [{"id": "ref-for-the-a-element\u2460\u24ea"}], "title": "8.3. Manual Biblio Links"}, {"refs": [{"id": "ref-for-the-a-element\u2460\u2460"}], "title": "10. WebIDL Processing"}, {"refs": [{"id": "ref-for-the-a-element\u2460\u2461"}], "title": "10.1. Putting Definitions Elsewhere"}], "external": true};
+window.dfnpanelData['2c82d279'] = {"dfnID": "2c82d279", "url": "https://html.spec.whatwg.org/multipage/media.html#audio", "dfnText": "audio", "refSections": [{"refs": [{"id": "ref-for-audio"}], "title": "4. Metadata"}], "external": true};
+window.dfnpanelData['2f0492ac'] = {"dfnID": "2f0492ac", "url": "https://html.spec.whatwg.org/multipage/sections.html#the-body-element", "dfnText": "body", "refSections": [{"refs": [{"id": "ref-for-the-body-element"}], "title": "12.5.1. Default Boilerplate"}], "external": true};
+window.dfnpanelData['84e9d123'] = {"dfnID": "84e9d123", "url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-code-element", "dfnText": "code", "refSections": [{"refs": [{"id": "ref-for-the-code-element"}], "title": "4. Metadata"}, {"refs": [{"id": "ref-for-the-code-element\u2460"}], "title": "5.6. Code Blocks (pre, etc)"}], "external": true};
+window.dfnpanelData['1b2e075f'] = {"dfnID": "1b2e075f", "url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-dd-element", "dfnText": "dd", "refSections": [{"refs": [{"id": "ref-for-the-dd-element"}, {"id": "ref-for-the-dd-element\u2460"}], "title": "4. Metadata"}], "external": true};
+window.dfnpanelData['b8cd3abf'] = {"dfnID": "b8cd3abf", "url": "https://html.spec.whatwg.org/multipage/edits.html#the-del-element", "dfnText": "del", "refSections": [{"refs": [{"id": "ref-for-the-del-element"}], "title": "4. Metadata"}], "external": true};
+window.dfnpanelData['b5bc22e1'] = {"dfnID": "b5bc22e1", "url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element", "dfnText": "dfn", "refSections": [{"refs": [{"id": "ref-for-the-dfn-element"}, {"id": "ref-for-the-dfn-element\u2460"}, {"id": "ref-for-the-dfn-element\u2461"}], "title": "4. Metadata"}, {"refs": [{"id": "ref-for-the-dfn-element\u2462"}, {"id": "ref-for-the-dfn-element\u2463"}], "title": "5.5. var and Algorithms"}, {"refs": [{"id": "ref-for-the-dfn-element\u2464"}], "title": "5.7. Automatic ID Generation"}, {"refs": [{"id": "ref-for-the-dfn-element\u2465"}], "title": "6. Definitions"}, {"refs": [{"id": "ref-for-the-dfn-element\u2466"}, {"id": "ref-for-the-dfn-element\u2467"}], "title": "6.1. Conjugating/Pluralizing/etc the Linking Text"}, {"refs": [{"id": "ref-for-the-dfn-element\u2468"}, {"id": "ref-for-the-dfn-element\u2460\u24ea"}, {"id": "ref-for-the-dfn-element\u2460\u2460"}], "title": "6.9. Definitions data model"}, {"refs": [{"id": "ref-for-the-dfn-element\u2460\u2461"}], "title": "7.3. Manual Autolinks"}, {"refs": [{"id": "ref-for-the-dfn-element\u2460\u2462"}], "title": "8. Bibliography"}, {"refs": [{"id": "ref-for-the-dfn-element\u2460\u2463"}], "title": "9.2. CSS Property Tables"}, {"refs": [{"id": "ref-for-the-dfn-element\u2460\u2464"}], "title": "9.4. HTML Element Tables"}, {"refs": [{"id": "ref-for-the-dfn-element\u2460\u2465"}], "title": "9.5. IDL Method Argument Tables"}, {"refs": [{"id": "ref-for-the-dfn-element\u2460\u2466"}], "title": "10. WebIDL Processing"}, {"refs": [{"id": "ref-for-the-dfn-element\u2460\u2467"}, {"id": "ref-for-the-dfn-element\u2460\u2468"}, {"id": "ref-for-the-dfn-element\u2461\u24ea"}], "title": "10.1. Putting Definitions Elsewhere"}, {"refs": [{"id": "ref-for-the-dfn-element\u2461\u2460"}], "title": "12.5. Boilerplate Sections"}], "external": true};
+window.dfnpanelData['8e8d7ce3'] = {"dfnID": "8e8d7ce3", "url": "https://html.spec.whatwg.org/multipage/dom.html#attr-dir", "dfnText": "dir", "refSections": [{"refs": [{"id": "ref-for-attr-dir"}], "title": "11.1. \nAnnotating Specs with Tests: the wpt element"}], "external": true};
+window.dfnpanelData['8960dd95'] = {"dfnID": "8960dd95", "url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element", "dfnText": "dl", "refSections": [{"refs": [{"id": "ref-for-the-dl-element"}], "title": "4. Metadata"}, {"refs": [{"id": "ref-for-the-dl-element\u2460"}], "title": "6.5. Namespacing a Definition"}, {"refs": [{"id": "ref-for-the-dl-element\u2461"}], "title": "12.5. Boilerplate Sections"}], "external": true};
+window.dfnpanelData['e70da718'] = {"dfnID": "e70da718", "url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-dt-element", "dfnText": "dt", "refSections": [{"refs": [{"id": "ref-for-the-dt-element"}], "title": "4. Metadata"}, {"refs": [{"id": "ref-for-the-dt-element\u2460"}], "title": "10.1.1. Free Type/Etc Documentation on Attributes/Dict Members"}, {"refs": [{"id": "ref-for-the-dt-element\u2461"}, {"id": "ref-for-the-dt-element\u2462"}], "title": "12.2. Rearranging and Excluding \"Spec Metadata\""}], "external": true};
+window.dfnpanelData['7a348049'] = {"dfnID": "7a348049", "url": "https://html.spec.whatwg.org/multipage/sections.html#the-h1-element", "dfnText": "h1", "refSections": [{"refs": [{"id": "ref-for-the-h1-element"}, {"id": "ref-for-the-h1-element\u2460"}, {"id": "ref-for-the-h1-element\u2461"}, {"id": "ref-for-the-h1-element\u2462"}, {"id": "ref-for-the-h1-element\u2463"}], "title": "4. Metadata"}, {"refs": [{"id": "ref-for-the-h1-element\u2464"}, {"id": "ref-for-the-h1-element\u2465"}], "title": "12.6. Table of Contents"}], "external": true};
+window.dfnpanelData['00f38254'] = {"dfnID": "00f38254", "url": "https://html.spec.whatwg.org/multipage/sections.html#the-h2-element", "dfnText": "h2", "refSections": [{"refs": [{"id": "ref-for-the-h2-element"}], "title": "6.9. Definitions data model"}, {"refs": [{"id": "ref-for-the-h2-element\u2460"}], "title": "12.6. Table of Contents"}], "external": true};
+window.dfnpanelData['321a7bd2'] = {"dfnID": "321a7bd2", "url": "https://html.spec.whatwg.org/multipage/sections.html#the-h6-element", "dfnText": "h6", "refSections": [{"refs": [{"id": "ref-for-the-h6-element"}], "title": "6.9. Definitions data model"}, {"refs": [{"id": "ref-for-the-h6-element\u2460"}], "title": "12.6. Table of Contents"}], "external": true};
+window.dfnpanelData['273ad187'] = {"dfnID": "273ad187", "url": "https://html.spec.whatwg.org/multipage/semantics.html#the-head-element", "dfnText": "head", "refSections": [{"refs": [{"id": "ref-for-the-head-element"}], "title": "12.4. Conditional Inclusion"}], "external": true};
+window.dfnpanelData['61fc66bc'] = {"dfnID": "61fc66bc", "url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-height", "dfnText": "height", "refSections": [{"refs": [{"id": "ref-for-attr-dim-height"}, {"id": "ref-for-attr-dim-height\u2460"}, {"id": "ref-for-attr-dim-height\u2461"}], "title": "5.13. Image Size Detection"}], "external": true};
+window.dfnpanelData['4c82b041'] = {"dfnID": "4c82b041", "url": "https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden", "dfnText": "hidden", "refSections": [{"refs": [{"id": "ref-for-attr-hidden"}], "title": "11.1. \nAnnotating Specs with Tests: the wpt element"}], "external": true};
+window.dfnpanelData['de4e0705'] = {"dfnID": "de4e0705", "url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-i-element", "dfnText": "i", "refSections": [{"refs": [{"id": "ref-for-the-i-element"}], "title": "4. Metadata"}], "external": true};
+window.dfnpanelData['482cc5af'] = {"dfnID": "482cc5af", "url": "https://html.spec.whatwg.org/multipage/images.html#image-source", "dfnText": "image source", "refSections": [{"refs": [{"id": "ref-for-image-source"}], "title": "5.13. Image Size Detection"}], "external": true};
+window.dfnpanelData['f0811ff8'] = {"dfnID": "f0811ff8", "url": "https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element", "dfnText": "img", "refSections": [{"refs": [{"id": "ref-for-the-img-element"}], "title": "4. Metadata"}, {"refs": [{"id": "ref-for-the-img-element\u2460"}], "title": "5.13. Image Size Detection"}], "external": true};
+window.dfnpanelData['d7d642a2'] = {"dfnID": "d7d642a2", "url": "https://html.spec.whatwg.org/multipage/input.html#the-input-element", "dfnText": "input", "refSections": [{"refs": [{"id": "ref-for-the-input-element"}], "title": "6.4. Definition Types"}], "external": true};
+window.dfnpanelData['e30e7b38'] = {"dfnID": "e30e7b38", "url": "https://html.spec.whatwg.org/multipage/dom.html#attr-lang", "dfnText": "lang", "refSections": [{"refs": [{"id": "ref-for-attr-lang"}], "title": "11.1. \nAnnotating Specs with Tests: the wpt element"}], "external": true};
+window.dfnpanelData['6cfa013d'] = {"dfnID": "6cfa013d", "url": "https://html.spec.whatwg.org/multipage/semantics.html#the-link-element", "dfnText": "link", "refSections": [{"refs": [{"id": "ref-for-the-link-element"}], "title": "4. Metadata"}], "external": true};
+window.dfnpanelData['4b24cbab'] = {"dfnID": "4b24cbab", "url": "https://html.spec.whatwg.org/multipage/images.html#pixel-density-descriptor", "dfnText": "pixel density descriptor", "refSections": [{"refs": [{"id": "ref-for-pixel-density-descriptor"}], "title": "5.13. Image Size Detection"}], "external": true};
+window.dfnpanelData['22a0e026'] = {"dfnID": "22a0e026", "url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element", "dfnText": "pre", "refSections": [{"refs": [{"id": "ref-for-the-pre-element"}, {"id": "ref-for-the-pre-element\u2460"}, {"id": "ref-for-the-pre-element\u2461"}, {"id": "ref-for-the-pre-element\u2462"}], "title": "4. Metadata"}, {"refs": [{"id": "ref-for-the-pre-element\u2463"}], "title": "5.4.1. \nAutolink Shortcuts That Work Anywhere: the l element"}, {"refs": [{"id": "ref-for-the-pre-element\u2464"}, {"id": "ref-for-the-pre-element\u2465"}], "title": "5.6. Code Blocks (pre, etc)"}, {"refs": [{"id": "ref-for-the-pre-element\u2466"}, {"id": "ref-for-the-pre-element\u2467"}, {"id": "ref-for-the-pre-element\u2468"}], "title": "5.6.1. pre whitespace stripping"}, {"refs": [{"id": "ref-for-the-pre-element\u2460\u24ea"}, {"id": "ref-for-the-pre-element\u2460\u2460"}, {"id": "ref-for-the-pre-element\u2460\u2461"}], "title": "5.6.2. xmp To Avoid Escaping Markup"}], "external": true};
+window.dfnpanelData['0cf3964f'] = {"dfnID": "0cf3964f", "url": "https://html.spec.whatwg.org/multipage/scripting.html#script", "dfnText": "script", "refSections": [{"refs": [{"id": "ref-for-script"}], "title": "4. Metadata"}, {"refs": [{"id": "ref-for-script\u2460"}], "title": "5.6.3. Syntax Highlighting"}], "external": true};
+window.dfnpanelData['918ee071'] = {"dfnID": "918ee071", "url": "https://html.spec.whatwg.org/multipage/sections.html#the-section-element", "dfnText": "section", "refSections": [{"refs": [{"id": "ref-for-the-section-element"}], "title": "12.6. Table of Contents"}], "external": true};
+window.dfnpanelData['b32b852a'] = {"dfnID": "b32b852a", "url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element", "dfnText": "span", "refSections": [{"refs": [{"id": "ref-for-the-span-element"}], "title": "4. Metadata"}], "external": true};
+window.dfnpanelData['b996b941'] = {"dfnID": "b996b941", "url": "https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-src", "dfnText": "src", "refSections": [{"refs": [{"id": "ref-for-attr-img-src"}, {"id": "ref-for-attr-img-src\u2460"}, {"id": "ref-for-attr-img-src\u2461"}], "title": "5.13. Image Size Detection"}], "external": true};
+window.dfnpanelData['c219fdf4'] = {"dfnID": "c219fdf4", "url": "https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset", "dfnText": "srcset", "refSections": [{"refs": [{"id": "ref-for-attr-img-srcset"}, {"id": "ref-for-attr-img-srcset\u2460"}, {"id": "ref-for-attr-img-srcset\u2461"}], "title": "5.13. Image Size Detection"}], "external": true};
+window.dfnpanelData['ba920583'] = {"dfnID": "ba920583", "url": "https://html.spec.whatwg.org/multipage/semantics.html#the-style-element", "dfnText": "style", "refSections": [{"refs": [{"id": "ref-for-the-style-element"}], "title": "5.6.3. Syntax Highlighting"}], "external": true};
+window.dfnpanelData['c6e0415b'] = {"dfnID": "c6e0415b", "url": "https://html.spec.whatwg.org/multipage/tables.html#the-table-element", "dfnText": "table", "refSections": [{"refs": [{"id": "ref-for-the-table-element"}], "title": "9. Definition Tables"}, {"refs": [{"id": "ref-for-the-table-element\u2460"}], "title": "12.4. Conditional Inclusion"}], "external": true};
+window.dfnpanelData['8ef0d91d'] = {"dfnID": "8ef0d91d", "url": "https://html.spec.whatwg.org/multipage/semantics.html#the-title-element", "dfnText": "title", "refSections": [{"refs": [{"id": "ref-for-the-title-element"}, {"id": "ref-for-the-title-element\u2460"}, {"id": "ref-for-the-title-element\u2461"}], "title": "4. Metadata"}], "external": true};
+window.dfnpanelData['ed5894fe'] = {"dfnID": "ed5894fe", "url": "https://html.spec.whatwg.org/multipage/dom.html#attr-title", "dfnText": "title (for html-global)", "refSections": [{"refs": [{"id": "ref-for-attr-title"}, {"id": "ref-for-attr-title\u2460"}, {"id": "ref-for-attr-title\u2461"}], "title": "11.1. \nAnnotating Specs with Tests: the wpt element"}], "external": true};
+window.dfnpanelData['5f91ca18'] = {"dfnID": "5f91ca18", "url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-var-element", "dfnText": "var", "refSections": [{"refs": [{"id": "ref-for-the-var-element"}, {"id": "ref-for-the-var-element\u2460"}], "title": "4. Metadata"}, {"refs": [{"id": "ref-for-the-var-element\u2461"}, {"id": "ref-for-the-var-element\u2462"}, {"id": "ref-for-the-var-element\u2463"}, {"id": "ref-for-the-var-element\u2464"}], "title": "5.5. var and Algorithms"}], "external": true};
+window.dfnpanelData['aa7bbf63'] = {"dfnID": "aa7bbf63", "url": "https://html.spec.whatwg.org/multipage/media.html#video", "dfnText": "video", "refSections": [{"refs": [{"id": "ref-for-video"}], "title": "4. Metadata"}], "external": true};
+window.dfnpanelData['45daa2a0'] = {"dfnID": "45daa2a0", "url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-width", "dfnText": "width", "refSections": [{"refs": [{"id": "ref-for-attr-dim-width"}, {"id": "ref-for-attr-dim-width\u2460"}, {"id": "ref-for-attr-dim-width\u2461"}], "title": "5.13. Image Size Detection"}], "external": true};
+window.dfnpanelData['2b692bb2'] = {"dfnID": "2b692bb2", "url": "https://html.spec.whatwg.org/multipage/obsolete.html#xmp", "dfnText": "xmp", "refSections": [{"refs": [{"id": "ref-for-xmp"}, {"id": "ref-for-xmp\u2460"}], "title": "4. Metadata"}, {"refs": [{"id": "ref-for-xmp\u2461"}], "title": "5.6. Code Blocks (pre, etc)"}, {"refs": [{"id": "ref-for-xmp\u2462"}, {"id": "ref-for-xmp\u2463"}, {"id": "ref-for-xmp\u2464"}, {"id": "ref-for-xmp\u2465"}, {"id": "ref-for-xmp\u2466"}, {"id": "ref-for-xmp\u2467"}, {"id": "ref-for-xmp\u2468"}], "title": "5.6.2. xmp To Avoid Escaping Markup"}], "external": true};
+window.dfnpanelData['d7384c6e'] = {"dfnID": "d7384c6e", "url": "https://infra.spec.whatwg.org/#tracking-vector", "dfnText": "tracking vector", "refSections": [{"refs": [{"id": "ref-for-tracking-vector"}], "title": "5.12. Tracking Vectors"}], "external": true};
+window.dfnpanelData['4299a926'] = {"dfnID": "4299a926", "url": "https://svgwg.org/svg2-draft/struct.html#elementdef-svg", "dfnText": "svg", "refSections": [{"refs": [{"id": "ref-for-elementdef-svg"}], "title": "13. Railroad Diagrams"}], "external": true};
+window.dfnpanelData['12ac1140'] = {"dfnID": "12ac1140", "url": "https://drafts.csswg.org/web-animations-1/#animation-type", "dfnText": "animation type", "refSections": [{"refs": [{"id": "ref-for-animation-type"}], "title": "9.2. CSS Property Tables"}], "external": true};
+window.dfnpanelData['8855a9aa'] = {"dfnID": "8855a9aa", "url": "https://webidl.spec.whatwg.org/#idl-DOMString", "dfnText": "DOMString", "refSections": [{"refs": [{"id": "ref-for-idl-DOMString"}, {"id": "ref-for-idl-DOMString\u2460"}], "title": "9.5. IDL Method Argument Tables"}], "external": true};
+window.dfnpanelData['f8de33a3'] = {"dfnID": "f8de33a3", "url": "https://webidl.spec.whatwg.org/#idl-long", "dfnText": "long", "refSections": [{"refs": [{"id": "ref-for-idl-long"}, {"id": "ref-for-idl-long\u2460"}], "title": "9.5. IDL Method Argument Tables"}], "external": true};
+window.dfnpanelData['5f90bbfb'] = {"dfnID": "5f90bbfb", "url": "https://webidl.spec.whatwg.org/#idl-undefined", "dfnText": "undefined", "refSections": [{"refs": [{"id": "ref-for-idl-undefined"}], "title": "9.5. IDL Method Argument Tables"}], "external": true};
+window.dfnpanelData['metadata-title'] = {"dfnID": "metadata-title", "url": "#metadata-title", "dfnText": "Title", "refSections": [{"refs": [{"id": "ref-for-metadata-title"}, {"id": "ref-for-metadata-title\u2460"}], "title": "4. Metadata"}, {"refs": [{"id": "ref-for-metadata-title\u2461"}], "title": "4.4. Ordering Between Metadata Sources"}], "external": false};
+window.dfnpanelData['metadata-status'] = {"dfnID": "metadata-status", "url": "#metadata-status", "dfnText": "Status", "refSections": [{"refs": [{"id": "ref-for-metadata-status"}], "title": "4. Metadata"}, {"refs": [{"id": "ref-for-metadata-status\u2460"}], "title": "12.4. Conditional Inclusion"}], "external": false};
+window.dfnpanelData['metadata-ed'] = {"dfnID": "metadata-ed", "url": "#metadata-ed", "dfnText": "ED", "refSections": [{"refs": [{"id": "ref-for-metadata-ed"}], "title": "12.2. Rearranging and Excluding \"Spec Metadata\""}], "external": false};
+window.dfnpanelData['metadata-editor'] = {"dfnID": "metadata-editor", "url": "#metadata-editor", "dfnText": "Editor", "refSections": [{"refs": [{"id": "ref-for-metadata-editor"}, {"id": "ref-for-metadata-editor\u2460"}], "title": "4. Metadata"}], "external": false};
+window.dfnpanelData['metadata-abstract'] = {"dfnID": "metadata-abstract", "url": "#metadata-abstract", "dfnText": "Abstract", "refSections": [{"refs": [{"id": "ref-for-metadata-abstract"}], "title": "4. Metadata"}], "external": false};
+window.dfnpanelData['metadata-die-on'] = {"dfnID": "metadata-die-on", "url": "#metadata-die-on", "dfnText": "Die On", "refSections": [{"refs": [{"id": "ref-for-metadata-die-on"}], "title": "3.1. Global Options"}], "external": false};
+window.dfnpanelData['metadata-die-when'] = {"dfnID": "metadata-die-when", "url": "#metadata-die-when", "dfnText": "Die When", "refSections": [{"refs": [{"id": "ref-for-metadata-die-when"}], "title": "3.1. Global Options"}], "external": false};
+window.dfnpanelData['metadata-h1'] = {"dfnID": "metadata-h1", "url": "#metadata-h1", "dfnText": "H1", "refSections": [{"refs": [{"id": "ref-for-metadata-h1"}, {"id": "ref-for-metadata-h1\u2460"}], "title": "4. Metadata"}], "external": false};
+window.dfnpanelData['metadata-group'] = {"dfnID": "metadata-group", "url": "#metadata-group", "dfnText": "Group", "refSections": [{"refs": [{"id": "ref-for-metadata-group"}], "title": "12.1. Groups"}], "external": false};
+window.dfnpanelData['metadata-date'] = {"dfnID": "metadata-date", "url": "#metadata-date", "dfnText": "Date", "refSections": [{"refs": [{"id": "ref-for-metadata-date"}], "title": "4. Metadata"}], "external": false};
+window.dfnpanelData['metadata-issue-tracking'] = {"dfnID": "metadata-issue-tracking", "url": "#metadata-issue-tracking", "dfnText": "Issue Tracking", "refSections": [{"refs": [{"id": "ref-for-metadata-issue-tracking"}], "title": "4. Metadata"}], "external": false};
+window.dfnpanelData['metadata-translation'] = {"dfnID": "metadata-translation", "url": "#metadata-translation", "dfnText": "Translation", "refSections": [{"refs": [{"id": "ref-for-metadata-translation"}], "title": "3.6. bikeshed update"}], "external": false};
+window.dfnpanelData['metadata-default-ref-status'] = {"dfnID": "metadata-default-ref-status", "url": "#metadata-default-ref-status", "dfnText": "Default Ref Status", "refSections": [{"refs": [{"id": "ref-for-metadata-default-ref-status"}], "title": "8.1. Biblio Link Modifiers"}], "external": false};
+window.dfnpanelData['metadata-default-biblio-display'] = {"dfnID": "metadata-default-biblio-display", "url": "#metadata-default-biblio-display", "dfnText": "Default Biblio Display", "refSections": [{"refs": [{"id": "ref-for-metadata-default-biblio-display"}], "title": "8.1. Biblio Link Modifiers"}], "external": false};
+window.dfnpanelData['metadata-markup-shorthands'] = {"dfnID": "metadata-markup-shorthands", "url": "#metadata-markup-shorthands", "dfnText": "Markup Shorthands", "refSections": [{"refs": [{"id": "ref-for-metadata-markup-shorthands"}, {"id": "ref-for-metadata-markup-shorthands\u2460"}], "title": "4. Metadata"}, {"refs": [{"id": "ref-for-metadata-markup-shorthands\u2461"}], "title": "5.4.1. \nAutolink Shortcuts That Work Anywhere: the l element"}], "external": false};
+window.dfnpanelData['metadata-text-macro'] = {"dfnID": "metadata-text-macro", "url": "#metadata-text-macro", "dfnText": "Text Macro", "refSections": [{"refs": [{"id": "ref-for-metadata-text-macro"}], "title": "4. Metadata"}, {"refs": [{"id": "ref-for-metadata-text-macro\u2460"}], "title": "4.2. Computing Metadata From Other Metadata"}, {"refs": [{"id": "ref-for-metadata-text-macro\u2461"}], "title": "12.4. Conditional Inclusion"}], "external": false};
+window.dfnpanelData['metadata-repository'] = {"dfnID": "metadata-repository", "url": "#metadata-repository", "dfnText": "Repository", "refSections": [{"refs": [{"id": "ref-for-metadata-repository"}, {"id": "ref-for-metadata-repository\u2460"}], "title": "4. Metadata"}], "external": false};
+window.dfnpanelData['metadata-inline-github-issues'] = {"dfnID": "metadata-inline-github-issues", "url": "#metadata-inline-github-issues", "dfnText": "Inline Github Issues", "refSections": [{"refs": [{"id": "ref-for-metadata-inline-github-issues"}], "title": "3.2. bikeshed spec"}], "external": false};
+window.dfnpanelData['metadata-note-class'] = {"dfnID": "metadata-note-class", "url": "#metadata-note-class", "dfnText": "Note Class", "refSections": [{"refs": [{"id": "ref-for-metadata-note-class"}], "title": "5.2. Notes, Issues, Examples, Advisements"}], "external": false};
+window.dfnpanelData['metadata-issue-class'] = {"dfnID": "metadata-issue-class", "url": "#metadata-issue-class", "dfnText": "Issue Class", "refSections": [{"refs": [{"id": "ref-for-metadata-issue-class"}], "title": "5.2. Notes, Issues, Examples, Advisements"}], "external": false};
+window.dfnpanelData['metadata-assertion-class'] = {"dfnID": "metadata-assertion-class", "url": "#metadata-assertion-class", "dfnText": "Assertion Class", "refSections": [{"refs": [{"id": "ref-for-metadata-assertion-class"}], "title": "5.2. Notes, Issues, Examples, Advisements"}], "external": false};
+window.dfnpanelData['metadata-advisement-class'] = {"dfnID": "metadata-advisement-class", "url": "#metadata-advisement-class", "dfnText": "Advisement Class", "refSections": [{"refs": [{"id": "ref-for-metadata-advisement-class"}], "title": "5.2. Notes, Issues, Examples, Advisements"}], "external": false};
+window.dfnpanelData['metadata-default-highlight'] = {"dfnID": "metadata-default-highlight", "url": "#metadata-default-highlight", "dfnText": "Default Highlight", "refSections": [{"refs": [{"id": "ref-for-metadata-default-highlight"}], "title": "5.6.3. Syntax Highlighting"}], "external": false};
+window.dfnpanelData['metadata-line-numbers'] = {"dfnID": "metadata-line-numbers", "url": "#metadata-line-numbers", "dfnText": "Line Numbers", "refSections": [{"refs": [{"id": "ref-for-metadata-line-numbers"}], "title": "5.6.4. Line Numbers"}], "external": false};
+window.dfnpanelData['metadata-boilerplate'] = {"dfnID": "metadata-boilerplate", "url": "#metadata-boilerplate", "dfnText": "Boilerplate", "refSections": [{"refs": [{"id": "ref-for-metadata-boilerplate"}], "title": "12.5.1. Default Boilerplate"}], "external": false};
+window.dfnpanelData['metadata-local-boilerplate'] = {"dfnID": "metadata-local-boilerplate", "url": "#metadata-local-boilerplate", "dfnText": "Local Boilerplate", "refSections": [{"refs": [{"id": "ref-for-metadata-local-boilerplate"}], "title": "2.1. Using Curl"}], "external": false};
+window.dfnpanelData['metadata-external-infotrees'] = {"dfnID": "metadata-external-infotrees", "url": "#metadata-external-infotrees", "dfnText": "External Infotrees", "refSections": [{"refs": [{"id": "ref-for-metadata-external-infotrees"}], "title": "2.1. Using Curl"}], "external": false};
+window.dfnpanelData['metadata-assume-explicit-for'] = {"dfnID": "metadata-assume-explicit-for", "url": "#metadata-assume-explicit-for", "dfnText": "Assume Explicit For", "refSections": [{"refs": [{"id": "ref-for-metadata-assume-explicit-for"}], "title": "7.1.2. Inside Syntax"}, {"refs": [{"id": "ref-for-metadata-assume-explicit-for\u2460"}], "title": "7.3. Manual Autolinks"}], "external": false};
+window.dfnpanelData['metadata-include-can-i-use-panels'] = {"dfnID": "metadata-include-can-i-use-panels", "url": "#metadata-include-can-i-use-panels", "dfnText": "Include Can I Use Panels", "refSections": [{"refs": [{"id": "ref-for-metadata-include-can-i-use-panels"}], "title": "4. Metadata"}], "external": false};
+window.dfnpanelData['metadata-can-i-use-url'] = {"dfnID": "metadata-can-i-use-url", "url": "#metadata-can-i-use-url", "dfnText": "Can I Use URL", "refSections": [{"refs": [{"id": "ref-for-metadata-can-i-use-url"}], "title": "4. Metadata"}], "external": false};
+window.dfnpanelData['metadata-custom-warning-title'] = {"dfnID": "metadata-custom-warning-title", "url": "#metadata-custom-warning-title", "dfnText": "Custom Warning Title", "refSections": [{"refs": [{"id": "ref-for-metadata-custom-warning-title"}], "title": "4. Metadata"}], "external": false};
+window.dfnpanelData['metadata-custom-warning-text'] = {"dfnID": "metadata-custom-warning-text", "url": "#metadata-custom-warning-text", "dfnText": "Custom Warning Text", "refSections": [{"refs": [{"id": "ref-for-metadata-custom-warning-text"}], "title": "4. Metadata"}], "external": false};
+window.dfnpanelData['metadata-prepare-for-tr'] = {"dfnID": "metadata-prepare-for-tr", "url": "#metadata-prepare-for-tr", "dfnText": "Prepare For TR", "refSections": [{"refs": [{"id": "ref-for-metadata-prepare-for-tr"}], "title": "3.5.1. Testing Publication Locally"}], "external": false};
+window.dfnpanelData['metadata-metadata-include'] = {"dfnID": "metadata-metadata-include", "url": "#metadata-metadata-include", "dfnText": "Metadata Include", "refSections": [{"refs": [{"id": "ref-for-metadata-metadata-include"}, {"id": "ref-for-metadata-metadata-include\u2460"}, {"id": "ref-for-metadata-metadata-include\u2461"}], "title": "12.2. Rearranging and Excluding \"Spec Metadata\""}], "external": false};
+window.dfnpanelData['metadata-metadata-order'] = {"dfnID": "metadata-metadata-order", "url": "#metadata-metadata-order", "dfnText": "Metadata Order", "refSections": [{"refs": [{"id": "ref-for-metadata-metadata-order"}, {"id": "ref-for-metadata-metadata-order\u2460"}], "title": "12.2. Rearranging and Excluding \"Spec Metadata\""}], "external": false};
+window.dfnpanelData['metadata-wpt-path-prefix'] = {"dfnID": "metadata-wpt-path-prefix", "url": "#metadata-wpt-path-prefix", "dfnText": "WPT Path Prefix", "refSections": [{"refs": [{"id": "ref-for-metadata-wpt-path-prefix"}, {"id": "ref-for-metadata-wpt-path-prefix\u2460"}, {"id": "ref-for-metadata-wpt-path-prefix\u2461"}, {"id": "ref-for-metadata-wpt-path-prefix\u2462"}], "title": "11.1. \nAnnotating Specs with Tests: the wpt element"}], "external": false};
+window.dfnpanelData['metadata-wpt-display'] = {"dfnID": "metadata-wpt-display", "url": "#metadata-wpt-display", "dfnText": "WPT Display", "refSections": [{"refs": [{"id": "ref-for-metadata-wpt-display"}], "title": "11.1. \nAnnotating Specs with Tests: the wpt element"}], "external": false};
+window.dfnpanelData['metadata-image-auto-size'] = {"dfnID": "metadata-image-auto-size", "url": "#metadata-image-auto-size", "dfnText": "Image Auto Size", "refSections": [{"refs": [{"id": "ref-for-metadata-image-auto-size"}], "title": "5.13. Image Size Detection"}], "external": false};
+window.dfnpanelData['boolish'] = {"dfnID": "boolish", "url": "#boolish", "dfnText": "boolish", "refSections": [{"refs": [{"id": "ref-for-boolish"}, {"id": "ref-for-boolish\u2460"}, {"id": "ref-for-boolish\u2461"}, {"id": "ref-for-boolish\u2462"}, {"id": "ref-for-boolish\u2463"}, {"id": "ref-for-boolish\u2464"}, {"id": "ref-for-boolish\u2465"}, {"id": "ref-for-boolish\u2466"}, {"id": "ref-for-boolish\u2467"}, {"id": "ref-for-boolish\u2468"}, {"id": "ref-for-boolish\u2460\u24ea"}, {"id": "ref-for-boolish\u2460\u2460"}, {"id": "ref-for-boolish\u2460\u2461"}, {"id": "ref-for-boolish\u2460\u2462"}, {"id": "ref-for-boolish\u2460\u2463"}, {"id": "ref-for-boolish\u2460\u2464"}, {"id": "ref-for-boolish\u2460\u2465"}, {"id": "ref-for-boolish\u2460\u2466"}, {"id": "ref-for-boolish\u2460\u2467"}, {"id": "ref-for-boolish\u2460\u2468"}, {"id": "ref-for-boolish\u2461\u24ea"}, {"id": "ref-for-boolish\u2461\u2460"}], "title": "4. Metadata"}, {"refs": [{"id": "ref-for-boolish\u2461\u2461"}], "title": "12.2. Rearranging and Excluding \"Spec Metadata\""}], "external": false};
+window.dfnpanelData['soft-boolish'] = {"dfnID": "soft-boolish", "url": "#soft-boolish", "dfnText": "soft boolish", "refSections": [{"refs": [{"id": "ref-for-soft-boolish"}, {"id": "ref-for-soft-boolish\u2460"}], "title": "4. Metadata"}], "external": false};
+window.dfnpanelData['l-element'] = {"dfnID": "l-element", "url": "#l-element", "dfnText": "5.4.1. \nAutolink Shortcuts That Work Anywhere: the l element", "refSections": [{"refs": [{"id": "ref-for-l-element"}, {"id": "ref-for-l-element"}, {"id": "ref-for-l-element\u2460"}, {"id": "ref-for-l-element\u2461"}, {"id": "ref-for-l-element\u2462"}], "title": "5.4.1. \nAutolink Shortcuts That Work Anywhere: the l element"}, {"refs": [{"id": "ref-for-l-element\u2463"}, {"id": "ref-for-l-element"}], "title": "7. Autolinking"}, {"refs": [{"id": "ref-for-l-element\u2464"}], "title": "7.3. Manual Autolinks"}, {"refs": [{"id": "ref-for-l-element\u2465"}], "title": "7.4. Link Types"}], "external": false};
+window.dfnpanelData['algorithms'] = {"dfnID": "algorithms", "url": "#algorithms", "dfnText": "Algorithms", "refSections": [{"refs": [{"id": "ref-for-algorithms"}], "title": "5.5. var and Algorithms"}], "external": false};
+window.dfnpanelData['dfn-autolink'] = {"dfnID": "dfn-autolink", "url": "#dfn-autolink", "dfnText": "Dfn autolinks", "refSections": [{"refs": [{"id": "ref-for-dfn-autolink"}, {"id": "ref-for-dfn-autolink\u2460"}, {"id": "ref-for-dfn-autolink\u2461"}, {"id": "ref-for-dfn-autolink\u2462"}, {"id": "ref-for-dfn-autolink\u2463"}, {"id": "ref-for-dfn-autolink\u2464"}], "title": "4. Metadata"}, {"refs": [{"id": "ref-for-dfn-autolink\u2465"}, {"id": "ref-for-dfn-autolink\u2466"}], "title": "7. Autolinking"}, {"refs": [{"id": "ref-for-dfn-autolink\u2467"}], "title": "7.2. Spec/Section Autolinks"}, {"refs": [{"id": "ref-for-dfn-autolink\u2468"}], "title": "7.4. Link Types"}], "external": false};
+window.dfnpanelData['biblio-autolink'] = {"dfnID": "biblio-autolink", "url": "#biblio-autolink", "dfnText": "Biblio/spec/section autolinks", "refSections": [{"refs": [{"id": "ref-for-biblio-autolink"}], "title": "7. Autolinking"}], "external": false};
+window.dfnpanelData['manual-autolink'] = {"dfnID": "manual-autolink", "url": "#manual-autolink", "dfnText": "manual autolink", "refSections": [{"refs": [{"id": "ref-for-manual-autolink"}], "title": "7. Autolinking"}], "external": false};
+window.dfnpanelData['dom-foo-bar'] = {"dfnID": "dom-foo-bar", "url": "#dom-foo-bar", "dfnText": "bar", "refSections": [{"refs": [{"id": "ref-for-dom-foo-bar"}], "title": "9.5. IDL Method Argument Tables"}], "external": false};
+window.dfnpanelData['wpt-element'] = {"dfnID": "wpt-element", "url": "#wpt-element", "dfnText": "11.1. \nAnnotating Specs with Tests: the wpt element", "refSections": [{"refs": [{"id": "ref-for-wpt-element"}, {"id": "ref-for-wpt-element\u2460"}], "title": "4. Metadata"}, {"refs": [{"id": "ref-for-wpt-element\u2461"}, {"id": "ref-for-wpt-element"}, {"id": "ref-for-wpt-element\u2462"}, {"id": "ref-for-wpt-element\u2463"}, {"id": "ref-for-wpt-element\u2464"}, {"id": "ref-for-wpt-element\u2465"}, {"id": "ref-for-wpt-element\u2466"}, {"id": "ref-for-wpt-element\u2467"}, {"id": "ref-for-wpt-element\u2468"}, {"id": "ref-for-wpt-element\u2460\u24ea"}, {"id": "ref-for-wpt-element\u2460\u2460"}, {"id": "ref-for-wpt-element\u2460\u2461"}, {"id": "ref-for-wpt-element\u2460\u2462"}, {"id": "ref-for-wpt-element\u2460\u2463"}, {"id": "ref-for-wpt-element\u2460\u2464"}, {"id": "ref-for-wpt-element\u2460\u2465"}, {"id": "ref-for-wpt-element\u2460\u2466"}, {"id": "ref-for-wpt-element\u2460\u2467"}, {"id": "ref-for-wpt-element\u2460\u2468"}, {"id": "ref-for-wpt-element\u2461\u24ea"}], "title": "11.1. \nAnnotating Specs with Tests: the wpt element"}], "external": false};
+window.dfnpanelData['element-attrdef-wpt-pathprefix'] = {"dfnID": "element-attrdef-wpt-pathprefix", "url": "#element-attrdef-wpt-pathprefix", "dfnText": "pathprefix", "refSections": [{"refs": [{"id": "ref-for-element-attrdef-wpt-pathprefix"}], "title": "11.1. \nAnnotating Specs with Tests: the wpt element"}], "external": false};
+window.dfnpanelData['elementdef-wpt-rest'] = {"dfnID": "elementdef-wpt-rest", "url": "#elementdef-wpt-rest", "dfnText": "<wpt-rest>", "refSections": [{"refs": [{"id": "ref-for-elementdef-wpt-rest"}], "title": "11.1. \nAnnotating Specs with Tests: the wpt element"}], "external": false};
+window.dfnpanelData['element-attrdef-global-include-if'] = {"dfnID": "element-attrdef-global-include-if", "url": "#element-attrdef-global-include-if", "dfnText": "include-if", "refSections": [{"refs": [{"id": "ref-for-element-attrdef-global-include-if"}], "title": "12.4. Conditional Inclusion"}], "external": false};
+window.dfnpanelData['element-attrdef-global-exclude-if'] = {"dfnID": "element-attrdef-global-exclude-if", "url": "#element-attrdef-global-exclude-if", "dfnText": "exclude-if", "refSections": [{"refs": [{"id": "ref-for-element-attrdef-global-exclude-if"}], "title": "12.4. Conditional Inclusion"}], "external": false};
+window.dfnpanelData['elementdef-if-wrapper'] = {"dfnID": "elementdef-if-wrapper", "url": "#elementdef-if-wrapper", "dfnText": "if-wrapper", "refSections": [{"refs": [{"id": "ref-for-elementdef-if-wrapper"}, {"id": "ref-for-elementdef-if-wrapper\u2460"}], "title": "12.4. Conditional Inclusion"}], "external": false};
+window.dfnpanelData['railroad-choice'] = {"dfnID": "railroad-choice", "url": "#railroad-choice", "dfnText": "Choice", "refSections": [{"refs": [{"id": "ref-for-railroad-choice"}], "title": "13.1. The Diagram Language"}], "external": false};
+window.dfnpanelData['railroad-optional'] = {"dfnID": "railroad-optional", "url": "#railroad-optional", "dfnText": "Optional", "refSections": [{"refs": [{"id": "ref-for-railroad-optional"}, {"id": "ref-for-railroad-optional\u2460"}], "title": "13.1. The Diagram Language"}], "external": false};
+window.dfnpanelData['railroad-oneormore'] = {"dfnID": "railroad-oneormore", "url": "#railroad-oneormore", "dfnText": "OneOrMore", "refSections": [{"refs": [{"id": "ref-for-railroad-oneormore"}, {"id": "ref-for-railroad-oneormore\u2460"}], "title": "13.1. The Diagram Language"}], "external": false};
+window.dfnpanelData['railroad-zeroormore'] = {"dfnID": "railroad-zeroormore", "url": "#railroad-zeroormore", "dfnText": "ZeroOrMore", "refSections": [{"refs": [{"id": "ref-for-railroad-zeroormore"}], "title": "13.1. The Diagram Language"}], "external": false};
+</script>
+<script>/* Boilerplate: script-dom-helper */
 function query(sel) { return document.querySelector(sel); }
 
 function queryAll(sel) { return [...document.querySelectorAll(sel)]; }
@@ -7254,923 +7683,6 @@ function parseHTML(markup) {
 		el.innerHTML = markup;
 		return el.content;
 	}
-}</script>
-<script>/* Boilerplate: script-dfn-panel */
-"use strict";
-{
-let dfnPanelData = {
-"00f38254": {"dfnID":"00f38254","dfnText":"h2","external":true,"refSections":[{"refs":[{"id":"ref-for-the-h2-element"}],"title":"6.9. Definitions data model"},{"refs":[{"id":"ref-for-the-h2-element\u2460"}],"title":"12.6. Table of Contents"}],"url":"https://html.spec.whatwg.org/multipage/sections.html#the-h2-element"},
-"0cf3964f": {"dfnID":"0cf3964f","dfnText":"script","external":true,"refSections":[{"refs":[{"id":"ref-for-script"}],"title":"4. Metadata"},{"refs":[{"id":"ref-for-script\u2460"}],"title":"5.6.3. Syntax Highlighting"}],"url":"https://html.spec.whatwg.org/multipage/scripting.html#script"},
-"12ac1140": {"dfnID":"12ac1140","dfnText":"animation type","external":true,"refSections":[{"refs":[{"id":"ref-for-animation-type"}],"title":"9.2. CSS Property Tables"}],"url":"https://drafts.csswg.org/web-animations-1/#animation-type"},
-"1b2e075f": {"dfnID":"1b2e075f","dfnText":"dd","external":true,"refSections":[{"refs":[{"id":"ref-for-the-dd-element"},{"id":"ref-for-the-dd-element\u2460"}],"title":"4. Metadata"}],"url":"https://html.spec.whatwg.org/multipage/grouping-content.html#the-dd-element"},
-"22a0e026": {"dfnID":"22a0e026","dfnText":"pre","external":true,"refSections":[{"refs":[{"id":"ref-for-the-pre-element"},{"id":"ref-for-the-pre-element\u2460"},{"id":"ref-for-the-pre-element\u2461"},{"id":"ref-for-the-pre-element\u2462"}],"title":"4. Metadata"},{"refs":[{"id":"ref-for-the-pre-element\u2463"}],"title":"5.4.1. \nAutolink Shortcuts That Work Anywhere: the l element"},{"refs":[{"id":"ref-for-the-pre-element\u2464"},{"id":"ref-for-the-pre-element\u2465"}],"title":"5.6. Code Blocks (pre, etc)"},{"refs":[{"id":"ref-for-the-pre-element\u2466"},{"id":"ref-for-the-pre-element\u2467"},{"id":"ref-for-the-pre-element\u2468"}],"title":"5.6.1. pre whitespace stripping"},{"refs":[{"id":"ref-for-the-pre-element\u2460\u24ea"},{"id":"ref-for-the-pre-element\u2460\u2460"},{"id":"ref-for-the-pre-element\u2460\u2461"}],"title":"5.6.2. xmp To Avoid Escaping Markup"}],"url":"https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element"},
-"24285d87": {"dfnID":"24285d87","dfnText":"flex container","external":true,"refSections":[{"refs":[{"id":"ref-for-flex-container"}],"title":"9.2. CSS Property Tables"}],"url":"https://drafts.csswg.org/css-flexbox-1/#flex-container"},
-"273ad187": {"dfnID":"273ad187","dfnText":"head","external":true,"refSections":[{"refs":[{"id":"ref-for-the-head-element"}],"title":"12.4. Conditional Inclusion"}],"url":"https://html.spec.whatwg.org/multipage/semantics.html#the-head-element"},
-"2b692bb2": {"dfnID":"2b692bb2","dfnText":"xmp","external":true,"refSections":[{"refs":[{"id":"ref-for-xmp"},{"id":"ref-for-xmp\u2460"}],"title":"4. Metadata"},{"refs":[{"id":"ref-for-xmp\u2461"}],"title":"5.6. Code Blocks (pre, etc)"},{"refs":[{"id":"ref-for-xmp\u2462"},{"id":"ref-for-xmp\u2463"},{"id":"ref-for-xmp\u2464"},{"id":"ref-for-xmp\u2465"},{"id":"ref-for-xmp\u2466"},{"id":"ref-for-xmp\u2467"},{"id":"ref-for-xmp\u2468"}],"title":"5.6.2. xmp To Avoid Escaping Markup"}],"url":"https://html.spec.whatwg.org/multipage/obsolete.html#xmp"},
-"2c82d279": {"dfnID":"2c82d279","dfnText":"audio","external":true,"refSections":[{"refs":[{"id":"ref-for-audio"}],"title":"4. Metadata"}],"url":"https://html.spec.whatwg.org/multipage/media.html#audio"},
-"2f0492ac": {"dfnID":"2f0492ac","dfnText":"body","external":true,"refSections":[{"refs":[{"id":"ref-for-the-body-element"}],"title":"12.5.1. Default Boilerplate"}],"url":"https://html.spec.whatwg.org/multipage/sections.html#the-body-element"},
-"321a7bd2": {"dfnID":"321a7bd2","dfnText":"h6","external":true,"refSections":[{"refs":[{"id":"ref-for-the-h6-element"}],"title":"6.9. Definitions data model"},{"refs":[{"id":"ref-for-the-h6-element\u2460"}],"title":"12.6. Table of Contents"}],"url":"https://html.spec.whatwg.org/multipage/sections.html#the-h6-element"},
-"4299a926": {"dfnID":"4299a926","dfnText":"svg","external":true,"refSections":[{"refs":[{"id":"ref-for-elementdef-svg"}],"title":"13. Railroad Diagrams"}],"url":"https://svgwg.org/svg2-draft/struct.html#elementdef-svg"},
-"45daa2a0": {"dfnID":"45daa2a0","dfnText":"width","external":true,"refSections":[{"refs":[{"id":"ref-for-attr-dim-width"},{"id":"ref-for-attr-dim-width\u2460"},{"id":"ref-for-attr-dim-width\u2461"}],"title":"5.13. Image Size Detection"}],"url":"https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-width"},
-"482cc5af": {"dfnID":"482cc5af","dfnText":"image source","external":true,"refSections":[{"refs":[{"id":"ref-for-image-source"}],"title":"5.13. Image Size Detection"}],"url":"https://html.spec.whatwg.org/multipage/images.html#image-source"},
-"4b24cbab": {"dfnID":"4b24cbab","dfnText":"pixel density descriptor","external":true,"refSections":[{"refs":[{"id":"ref-for-pixel-density-descriptor"}],"title":"5.13. Image Size Detection"}],"url":"https://html.spec.whatwg.org/multipage/images.html#pixel-density-descriptor"},
-"4c82b041": {"dfnID":"4c82b041","dfnText":"hidden","external":true,"refSections":[{"refs":[{"id":"ref-for-attr-hidden"}],"title":"11.1. \nAnnotating Specs with Tests: the wpt element"}],"url":"https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden"},
-"5f90bbfb": {"dfnID":"5f90bbfb","dfnText":"undefined","external":true,"refSections":[{"refs":[{"id":"ref-for-idl-undefined"}],"title":"9.5. IDL Method Argument Tables"}],"url":"https://webidl.spec.whatwg.org/#idl-undefined"},
-"5f91ca18": {"dfnID":"5f91ca18","dfnText":"var","external":true,"refSections":[{"refs":[{"id":"ref-for-the-var-element"},{"id":"ref-for-the-var-element\u2460"}],"title":"4. Metadata"},{"refs":[{"id":"ref-for-the-var-element\u2461"},{"id":"ref-for-the-var-element\u2462"},{"id":"ref-for-the-var-element\u2463"},{"id":"ref-for-the-var-element\u2464"}],"title":"5.5. var and Algorithms"}],"url":"https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-var-element"},
-"61fc66bc": {"dfnID":"61fc66bc","dfnText":"height","external":true,"refSections":[{"refs":[{"id":"ref-for-attr-dim-height"},{"id":"ref-for-attr-dim-height\u2460"},{"id":"ref-for-attr-dim-height\u2461"}],"title":"5.13. Image Size Detection"}],"url":"https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-height"},
-"66c521a7": {"dfnID":"66c521a7","dfnText":"flex item","external":true,"refSections":[{"refs":[{"id":"ref-for-flex-item"}],"title":"9.2. CSS Property Tables"}],"url":"https://drafts.csswg.org/css-flexbox-1/#flex-item"},
-"68bf3d31": {"dfnID":"68bf3d31","dfnText":"a","external":true,"refSections":[{"refs":[{"id":"ref-for-the-a-element"}],"title":"4. Metadata"},{"refs":[{"id":"ref-for-the-a-element\u2460"},{"id":"ref-for-the-a-element\u2461"},{"id":"ref-for-the-a-element\u2462"}],"title":"5.4.1. \nAutolink Shortcuts That Work Anywhere: the l element"},{"refs":[{"id":"ref-for-the-a-element\u2463"}],"title":"6.1. Conjugating/Pluralizing/etc the Linking Text"},{"refs":[{"id":"ref-for-the-a-element\u2464"},{"id":"ref-for-the-a-element\u2465"}],"title":"7. Autolinking"},{"refs":[{"id":"ref-for-the-a-element\u2466"},{"id":"ref-for-the-a-element\u2467"}],"title":"7.3. Manual Autolinks"},{"refs":[{"id":"ref-for-the-a-element\u2468"}],"title":"7.4. Link Types"},{"refs":[{"id":"ref-for-the-a-element\u2460\u24ea"}],"title":"8.3. Manual Biblio Links"},{"refs":[{"id":"ref-for-the-a-element\u2460\u2460"}],"title":"10. WebIDL Processing"},{"refs":[{"id":"ref-for-the-a-element\u2460\u2461"}],"title":"10.1. Putting Definitions Elsewhere"}],"url":"https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"},
-"6cfa013d": {"dfnID":"6cfa013d","dfnText":"link","external":true,"refSections":[{"refs":[{"id":"ref-for-the-link-element"}],"title":"4. Metadata"}],"url":"https://html.spec.whatwg.org/multipage/semantics.html#the-link-element"},
-"73c10739": {"dfnID":"73c10739","dfnText":"main size","external":true,"refSections":[{"refs":[{"id":"ref-for-main-size"}],"title":"9.2. CSS Property Tables"}],"url":"https://drafts.csswg.org/css-flexbox-1/#main-size"},
-"7a348049": {"dfnID":"7a348049","dfnText":"h1","external":true,"refSections":[{"refs":[{"id":"ref-for-the-h1-element"},{"id":"ref-for-the-h1-element\u2460"},{"id":"ref-for-the-h1-element\u2461"},{"id":"ref-for-the-h1-element\u2462"},{"id":"ref-for-the-h1-element\u2463"}],"title":"4. Metadata"},{"refs":[{"id":"ref-for-the-h1-element\u2464"},{"id":"ref-for-the-h1-element\u2465"}],"title":"12.6. Table of Contents"}],"url":"https://html.spec.whatwg.org/multipage/sections.html#the-h1-element"},
-"84e9d123": {"dfnID":"84e9d123","dfnText":"code","external":true,"refSections":[{"refs":[{"id":"ref-for-the-code-element"}],"title":"4. Metadata"},{"refs":[{"id":"ref-for-the-code-element\u2460"}],"title":"5.6. Code Blocks (pre, etc)"}],"url":"https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-code-element"},
-"8855a9aa": {"dfnID":"8855a9aa","dfnText":"DOMString","external":true,"refSections":[{"refs":[{"id":"ref-for-idl-DOMString"},{"id":"ref-for-idl-DOMString\u2460"}],"title":"9.5. IDL Method Argument Tables"}],"url":"https://webidl.spec.whatwg.org/#idl-DOMString"},
-"8960dd95": {"dfnID":"8960dd95","dfnText":"dl","external":true,"refSections":[{"refs":[{"id":"ref-for-the-dl-element"}],"title":"4. Metadata"},{"refs":[{"id":"ref-for-the-dl-element\u2460"}],"title":"6.5. Namespacing a Definition"},{"refs":[{"id":"ref-for-the-dl-element\u2461"}],"title":"12.5. Boilerplate Sections"}],"url":"https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element"},
-"8e8d7ce3": {"dfnID":"8e8d7ce3","dfnText":"dir","external":true,"refSections":[{"refs":[{"id":"ref-for-attr-dir"}],"title":"11.1. \nAnnotating Specs with Tests: the wpt element"}],"url":"https://html.spec.whatwg.org/multipage/dom.html#attr-dir"},
-"8ef0d91d": {"dfnID":"8ef0d91d","dfnText":"title","external":true,"refSections":[{"refs":[{"id":"ref-for-the-title-element"},{"id":"ref-for-the-title-element\u2460"},{"id":"ref-for-the-title-element\u2461"}],"title":"4. Metadata"}],"url":"https://html.spec.whatwg.org/multipage/semantics.html#the-title-element"},
-"918ee071": {"dfnID":"918ee071","dfnText":"section","external":true,"refSections":[{"refs":[{"id":"ref-for-the-section-element"}],"title":"12.6. Table of Contents"}],"url":"https://html.spec.whatwg.org/multipage/sections.html#the-section-element"},
-"aa7bbf63": {"dfnID":"aa7bbf63","dfnText":"video","external":true,"refSections":[{"refs":[{"id":"ref-for-video"}],"title":"4. Metadata"}],"url":"https://html.spec.whatwg.org/multipage/media.html#video"},
-"algorithms": {"dfnID":"algorithms","dfnText":"Algorithms","external":false,"refSections":[{"refs":[{"id":"ref-for-algorithms"}],"title":"5.5. var and Algorithms"}],"url":"#algorithms"},
-"b32b852a": {"dfnID":"b32b852a","dfnText":"span","external":true,"refSections":[{"refs":[{"id":"ref-for-the-span-element"}],"title":"4. Metadata"}],"url":"https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element"},
-"b5bc22e1": {"dfnID":"b5bc22e1","dfnText":"dfn","external":true,"refSections":[{"refs":[{"id":"ref-for-the-dfn-element"},{"id":"ref-for-the-dfn-element\u2460"},{"id":"ref-for-the-dfn-element\u2461"}],"title":"4. Metadata"},{"refs":[{"id":"ref-for-the-dfn-element\u2462"},{"id":"ref-for-the-dfn-element\u2463"}],"title":"5.5. var and Algorithms"},{"refs":[{"id":"ref-for-the-dfn-element\u2464"}],"title":"5.7. Automatic ID Generation"},{"refs":[{"id":"ref-for-the-dfn-element\u2465"}],"title":"6. Definitions"},{"refs":[{"id":"ref-for-the-dfn-element\u2466"},{"id":"ref-for-the-dfn-element\u2467"}],"title":"6.1. Conjugating/Pluralizing/etc the Linking Text"},{"refs":[{"id":"ref-for-the-dfn-element\u2468"},{"id":"ref-for-the-dfn-element\u2460\u24ea"},{"id":"ref-for-the-dfn-element\u2460\u2460"}],"title":"6.9. Definitions data model"},{"refs":[{"id":"ref-for-the-dfn-element\u2460\u2461"}],"title":"7.3. Manual Autolinks"},{"refs":[{"id":"ref-for-the-dfn-element\u2460\u2462"}],"title":"8. Bibliography"},{"refs":[{"id":"ref-for-the-dfn-element\u2460\u2463"}],"title":"9.2. CSS Property Tables"},{"refs":[{"id":"ref-for-the-dfn-element\u2460\u2464"}],"title":"9.4. HTML Element Tables"},{"refs":[{"id":"ref-for-the-dfn-element\u2460\u2465"}],"title":"9.5. IDL Method Argument Tables"},{"refs":[{"id":"ref-for-the-dfn-element\u2460\u2466"}],"title":"10. WebIDL Processing"},{"refs":[{"id":"ref-for-the-dfn-element\u2460\u2467"},{"id":"ref-for-the-dfn-element\u2460\u2468"},{"id":"ref-for-the-dfn-element\u2461\u24ea"}],"title":"10.1. Putting Definitions Elsewhere"},{"refs":[{"id":"ref-for-the-dfn-element\u2461\u2460"}],"title":"12.5. Boilerplate Sections"}],"url":"https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element"},
-"b8cd3abf": {"dfnID":"b8cd3abf","dfnText":"del","external":true,"refSections":[{"refs":[{"id":"ref-for-the-del-element"}],"title":"4. Metadata"}],"url":"https://html.spec.whatwg.org/multipage/edits.html#the-del-element"},
-"b996b941": {"dfnID":"b996b941","dfnText":"src","external":true,"refSections":[{"refs":[{"id":"ref-for-attr-img-src"},{"id":"ref-for-attr-img-src\u2460"},{"id":"ref-for-attr-img-src\u2461"}],"title":"5.13. Image Size Detection"}],"url":"https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-src"},
-"ba920583": {"dfnID":"ba920583","dfnText":"style","external":true,"refSections":[{"refs":[{"id":"ref-for-the-style-element"}],"title":"5.6.3. Syntax Highlighting"}],"url":"https://html.spec.whatwg.org/multipage/semantics.html#the-style-element"},
-"biblio-autolink": {"dfnID":"biblio-autolink","dfnText":"Biblio/spec/section autolinks","external":false,"refSections":[{"refs":[{"id":"ref-for-biblio-autolink"}],"title":"7. Autolinking"}],"url":"#biblio-autolink"},
-"boolish": {"dfnID":"boolish","dfnText":"boolish","external":false,"refSections":[{"refs":[{"id":"ref-for-boolish"},{"id":"ref-for-boolish\u2460"},{"id":"ref-for-boolish\u2461"},{"id":"ref-for-boolish\u2462"},{"id":"ref-for-boolish\u2463"},{"id":"ref-for-boolish\u2464"},{"id":"ref-for-boolish\u2465"},{"id":"ref-for-boolish\u2466"},{"id":"ref-for-boolish\u2467"},{"id":"ref-for-boolish\u2468"},{"id":"ref-for-boolish\u2460\u24ea"},{"id":"ref-for-boolish\u2460\u2460"},{"id":"ref-for-boolish\u2460\u2461"},{"id":"ref-for-boolish\u2460\u2462"},{"id":"ref-for-boolish\u2460\u2463"},{"id":"ref-for-boolish\u2460\u2464"},{"id":"ref-for-boolish\u2460\u2465"},{"id":"ref-for-boolish\u2460\u2466"},{"id":"ref-for-boolish\u2460\u2467"},{"id":"ref-for-boolish\u2460\u2468"},{"id":"ref-for-boolish\u2461\u24ea"},{"id":"ref-for-boolish\u2461\u2460"}],"title":"4. Metadata"},{"refs":[{"id":"ref-for-boolish\u2461\u2461"}],"title":"12.2. Rearranging and Excluding \"Spec Metadata\""}],"url":"#boolish"},
-"c219fdf4": {"dfnID":"c219fdf4","dfnText":"srcset","external":true,"refSections":[{"refs":[{"id":"ref-for-attr-img-srcset"},{"id":"ref-for-attr-img-srcset\u2460"},{"id":"ref-for-attr-img-srcset\u2461"}],"title":"5.13. Image Size Detection"}],"url":"https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset"},
-"c6e0415b": {"dfnID":"c6e0415b","dfnText":"table","external":true,"refSections":[{"refs":[{"id":"ref-for-the-table-element"}],"title":"9. Definition Tables"},{"refs":[{"id":"ref-for-the-table-element\u2460"}],"title":"12.4. Conditional Inclusion"}],"url":"https://html.spec.whatwg.org/multipage/tables.html#the-table-element"},
-"d7384c6e": {"dfnID":"d7384c6e","dfnText":"tracking vector","external":true,"refSections":[{"refs":[{"id":"ref-for-tracking-vector"}],"title":"5.12. Tracking Vectors"}],"url":"https://infra.spec.whatwg.org/#tracking-vector"},
-"d7d642a2": {"dfnID":"d7d642a2","dfnText":"input","external":true,"refSections":[{"refs":[{"id":"ref-for-the-input-element"}],"title":"6.4. Definition Types"}],"url":"https://html.spec.whatwg.org/multipage/input.html#the-input-element"},
-"de4e0705": {"dfnID":"de4e0705","dfnText":"i","external":true,"refSections":[{"refs":[{"id":"ref-for-the-i-element"}],"title":"4. Metadata"}],"url":"https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-i-element"},
-"dfn-autolink": {"dfnID":"dfn-autolink","dfnText":"Dfn autolinks","external":false,"refSections":[{"refs":[{"id":"ref-for-dfn-autolink"},{"id":"ref-for-dfn-autolink\u2460"},{"id":"ref-for-dfn-autolink\u2461"},{"id":"ref-for-dfn-autolink\u2462"},{"id":"ref-for-dfn-autolink\u2463"},{"id":"ref-for-dfn-autolink\u2464"}],"title":"4. Metadata"},{"refs":[{"id":"ref-for-dfn-autolink\u2465"},{"id":"ref-for-dfn-autolink\u2466"}],"title":"7. Autolinking"},{"refs":[{"id":"ref-for-dfn-autolink\u2467"}],"title":"7.2. Spec/Section Autolinks"},{"refs":[{"id":"ref-for-dfn-autolink\u2468"}],"title":"7.4. Link Types"}],"url":"#dfn-autolink"},
-"dom-foo-bar": {"dfnID":"dom-foo-bar","dfnText":"bar","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-foo-bar"}],"title":"9.5. IDL Method Argument Tables"}],"url":"#dom-foo-bar"},
-"dom-foo-bar-arg1": {"dfnID":"dom-foo-bar-arg1","dfnText":"arg1","external":false,"refSections":[],"url":"#dom-foo-bar-arg1"},
-"dom-foo-bar-arg1-arg2-arg1": {"dfnID":"dom-foo-bar-arg1-arg2-arg1","dfnText":"arg1","external":false,"refSections":[],"url":"#dom-foo-bar-arg1-arg2-arg1"},
-"dom-foo-bar-arg1-arg2-arg2": {"dfnID":"dom-foo-bar-arg1-arg2-arg2","dfnText":"arg2","external":false,"refSections":[],"url":"#dom-foo-bar-arg1-arg2-arg2"},
-"dom-foo-bar-arg2": {"dfnID":"dom-foo-bar-arg2","dfnText":"arg2","external":false,"refSections":[],"url":"#dom-foo-bar-arg2"},
-"dom-wpt-skip-existence-check": {"dfnID":"dom-wpt-skip-existence-check","dfnText":"skip-existence-check","external":false,"refSections":[],"url":"#dom-wpt-skip-existence-check"},
-"e30e7b38": {"dfnID":"e30e7b38","dfnText":"lang","external":true,"refSections":[{"refs":[{"id":"ref-for-attr-lang"}],"title":"11.1. \nAnnotating Specs with Tests: the wpt element"}],"url":"https://html.spec.whatwg.org/multipage/dom.html#attr-lang"},
-"e70da718": {"dfnID":"e70da718","dfnText":"dt","external":true,"refSections":[{"refs":[{"id":"ref-for-the-dt-element"}],"title":"4. Metadata"},{"refs":[{"id":"ref-for-the-dt-element\u2460"}],"title":"10.1.1. Free Type/Etc Documentation on Attributes/Dict Members"},{"refs":[{"id":"ref-for-the-dt-element\u2461"},{"id":"ref-for-the-dt-element\u2462"}],"title":"12.2. Rearranging and Excluding \"Spec Metadata\""}],"url":"https://html.spec.whatwg.org/multipage/grouping-content.html#the-dt-element"},
-"eb3aa672": {"dfnID":"eb3aa672","dfnText":"logical property group","external":true,"refSections":[{"refs":[{"id":"ref-for-logical-property-group"}],"title":"9.2. CSS Property Tables"}],"url":"https://drafts.csswg.org/css-logical-1/#logical-property-group"},
-"ed5894fe": {"dfnID":"ed5894fe","dfnText":"title (for html-global)","external":true,"refSections":[{"refs":[{"id":"ref-for-attr-title"},{"id":"ref-for-attr-title\u2460"},{"id":"ref-for-attr-title\u2461"}],"title":"11.1. \nAnnotating Specs with Tests: the wpt element"}],"url":"https://html.spec.whatwg.org/multipage/dom.html#attr-title"},
-"element-attrdef-global-exclude-if": {"dfnID":"element-attrdef-global-exclude-if","dfnText":"exclude-if","external":false,"refSections":[{"refs":[{"id":"ref-for-element-attrdef-global-exclude-if"}],"title":"12.4. Conditional Inclusion"}],"url":"#element-attrdef-global-exclude-if"},
-"element-attrdef-global-include-if": {"dfnID":"element-attrdef-global-include-if","dfnText":"include-if","external":false,"refSections":[{"refs":[{"id":"ref-for-element-attrdef-global-include-if"}],"title":"12.4. Conditional Inclusion"}],"url":"#element-attrdef-global-include-if"},
-"element-attrdef-img-no-autosize": {"dfnID":"element-attrdef-img-no-autosize","dfnText":"no-autosize","external":false,"refSections":[],"url":"#element-attrdef-img-no-autosize"},
-"element-attrdef-wpt-pathprefix": {"dfnID":"element-attrdef-wpt-pathprefix","dfnText":"pathprefix","external":false,"refSections":[{"refs":[{"id":"ref-for-element-attrdef-wpt-pathprefix"}],"title":"11.1. \nAnnotating Specs with Tests: the wpt element"}],"url":"#element-attrdef-wpt-pathprefix"},
-"elementdef-if-wrapper": {"dfnID":"elementdef-if-wrapper","dfnText":"if-wrapper","external":false,"refSections":[{"refs":[{"id":"ref-for-elementdef-if-wrapper"},{"id":"ref-for-elementdef-if-wrapper\u2460"}],"title":"12.4. Conditional Inclusion"}],"url":"#elementdef-if-wrapper"},
-"elementdef-wpt-rest": {"dfnID":"elementdef-wpt-rest","dfnText":"<wpt-rest>","external":false,"refSections":[{"refs":[{"id":"ref-for-elementdef-wpt-rest"}],"title":"11.1. \nAnnotating Specs with Tests: the wpt element"}],"url":"#elementdef-wpt-rest"},
-"f0811ff8": {"dfnID":"f0811ff8","dfnText":"img","external":true,"refSections":[{"refs":[{"id":"ref-for-the-img-element"}],"title":"4. Metadata"},{"refs":[{"id":"ref-for-the-img-element\u2460"}],"title":"5.13. Image Size Detection"}],"url":"https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element"},
-"f8de33a3": {"dfnID":"f8de33a3","dfnText":"long","external":true,"refSections":[{"refs":[{"id":"ref-for-idl-long"},{"id":"ref-for-idl-long\u2460"}],"title":"9.5. IDL Method Argument Tables"}],"url":"https://webidl.spec.whatwg.org/#idl-long"},
-"foo": {"dfnID":"foo","dfnText":"Foo","external":false,"refSections":[],"url":"#foo"},
-"l-element": {"dfnID":"l-element","dfnText":"5.4.1. \nAutolink Shortcuts That Work Anywhere: the l element","external":false,"refSections":[{"refs":[{"id":"ref-for-l-element"},{"id":"ref-for-l-element"},{"id":"ref-for-l-element\u2460"},{"id":"ref-for-l-element\u2461"},{"id":"ref-for-l-element\u2462"}],"title":"5.4.1. \nAutolink Shortcuts That Work Anywhere: the l element"},{"refs":[{"id":"ref-for-l-element\u2463"},{"id":"ref-for-l-element"}],"title":"7. Autolinking"},{"refs":[{"id":"ref-for-l-element\u2464"}],"title":"7.3. Manual Autolinks"},{"refs":[{"id":"ref-for-l-element\u2465"}],"title":"7.4. Link Types"}],"url":"#l-element"},
-"macro-abstract": {"dfnID":"macro-abstract","dfnText":"[ABSTRACT]","external":false,"refSections":[],"url":"#macro-abstract"},
-"macro-abstractattr": {"dfnID":"macro-abstractattr","dfnText":"[ABSTRACTATTR]","external":false,"refSections":[],"url":"#macro-abstractattr"},
-"macro-cdate": {"dfnID":"macro-cdate","dfnText":"[CDATE]","external":false,"refSections":[],"url":"#macro-cdate"},
-"macro-date": {"dfnID":"macro-date","dfnText":"[DATE]","external":false,"refSections":[{"refs":[{"id":"ref-for-macro-date"}],"title":"12.3. Text Macros"}],"url":"#macro-date"},
-"macro-date-dmmy": {"dfnID":"macro-date-dmmy","dfnText":"[DATE-DMMY]","external":false,"refSections":[],"url":"#macro-date-dmmy"},
-"macro-date-mmy": {"dfnID":"macro-date-mmy","dfnText":"[DATE-MMY]","external":false,"refSections":[],"url":"#macro-date-mmy"},
-"macro-date-my": {"dfnID":"macro-date-my","dfnText":"[DATE-MY]","external":false,"refSections":[],"url":"#macro-date-my"},
-"macro-deadline": {"dfnID":"macro-deadline","dfnText":"[DEADLINE]","external":false,"refSections":[],"url":"#macro-deadline"},
-"macro-h1": {"dfnID":"macro-h1","dfnText":"[H1]","external":false,"refSections":[],"url":"#macro-h1"},
-"macro-isodate": {"dfnID":"macro-isodate","dfnText":"[ISODATE]","external":false,"refSections":[],"url":"#macro-isodate"},
-"macro-latest": {"dfnID":"macro-latest","dfnText":"[LATEST]","external":false,"refSections":[],"url":"#macro-latest"},
-"macro-logo": {"dfnID":"macro-logo","dfnText":"[LOGO]","external":false,"refSections":[],"url":"#macro-logo"},
-"macro-longstatus": {"dfnID":"macro-longstatus","dfnText":"[LONGSTATUS]","external":false,"refSections":[],"url":"#macro-longstatus"},
-"macro-repository": {"dfnID":"macro-repository","dfnText":"[REPOSITORY]","external":false,"refSections":[],"url":"#macro-repository"},
-"macro-shortname": {"dfnID":"macro-shortname","dfnText":"[SHORTNAME]","external":false,"refSections":[],"url":"#macro-shortname"},
-"macro-status": {"dfnID":"macro-status","dfnText":"[STATUS]","external":false,"refSections":[],"url":"#macro-status"},
-"macro-statustext": {"dfnID":"macro-statustext","dfnText":"[STATUSTEXT]","external":false,"refSections":[],"url":"#macro-statustext"},
-"macro-title": {"dfnID":"macro-title","dfnText":"[TITLE]","external":false,"refSections":[],"url":"#macro-title"},
-"macro-version": {"dfnID":"macro-version","dfnText":"[VERSION]","external":false,"refSections":[],"url":"#macro-version"},
-"macro-vshortname": {"dfnID":"macro-vshortname","dfnText":"[VSHORTNAME]","external":false,"refSections":[],"url":"#macro-vshortname"},
-"macro-year": {"dfnID":"macro-year","dfnText":"[YEAR]","external":false,"refSections":[],"url":"#macro-year"},
-"manual-autolink": {"dfnID":"manual-autolink","dfnText":"manual autolink","external":false,"refSections":[{"refs":[{"id":"ref-for-manual-autolink"}],"title":"7. Autolinking"}],"url":"#manual-autolink"},
-"metadata-abstract": {"dfnID":"metadata-abstract","dfnText":"Abstract","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-abstract"}],"title":"4. Metadata"}],"url":"#metadata-abstract"},
-"metadata-advisement-class": {"dfnID":"metadata-advisement-class","dfnText":"Advisement Class","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-advisement-class"}],"title":"5.2. Notes, Issues, Examples, Advisements"}],"url":"#metadata-advisement-class"},
-"metadata-assertion-class": {"dfnID":"metadata-assertion-class","dfnText":"Assertion Class","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-assertion-class"}],"title":"5.2. Notes, Issues, Examples, Advisements"}],"url":"#metadata-assertion-class"},
-"metadata-assume-explicit-for": {"dfnID":"metadata-assume-explicit-for","dfnText":"Assume Explicit For","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-assume-explicit-for"}],"title":"7.1.2. Inside Syntax"},{"refs":[{"id":"ref-for-metadata-assume-explicit-for\u2460"}],"title":"7.3. Manual Autolinks"}],"url":"#metadata-assume-explicit-for"},
-"metadata-at-risk": {"dfnID":"metadata-at-risk","dfnText":"At Risk","external":false,"refSections":[],"url":"#metadata-at-risk"},
-"metadata-block-elements": {"dfnID":"metadata-block-elements","dfnText":"Block Elements","external":false,"refSections":[],"url":"#metadata-block-elements"},
-"metadata-boilerplate": {"dfnID":"metadata-boilerplate","dfnText":"Boilerplate","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-boilerplate"}],"title":"12.5.1. Default Boilerplate"}],"url":"#metadata-boilerplate"},
-"metadata-can-i-use-url": {"dfnID":"metadata-can-i-use-url","dfnText":"Can I Use URL","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-can-i-use-url"}],"title":"4. Metadata"}],"url":"#metadata-can-i-use-url"},
-"metadata-canonical-url": {"dfnID":"metadata-canonical-url","dfnText":"Canonical URL","external":false,"refSections":[],"url":"#metadata-canonical-url"},
-"metadata-complain-about": {"dfnID":"metadata-complain-about","dfnText":"Complain About","external":false,"refSections":[],"url":"#metadata-complain-about"},
-"metadata-custom-warning-text": {"dfnID":"metadata-custom-warning-text","dfnText":"Custom Warning Text","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-custom-warning-text"}],"title":"4. Metadata"}],"url":"#metadata-custom-warning-text"},
-"metadata-custom-warning-title": {"dfnID":"metadata-custom-warning-title","dfnText":"Custom Warning Title","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-custom-warning-title"}],"title":"4. Metadata"}],"url":"#metadata-custom-warning-title"},
-"metadata-dark-mode": {"dfnID":"metadata-dark-mode","dfnText":"Dark Mode","external":false,"refSections":[],"url":"#metadata-dark-mode"},
-"metadata-date": {"dfnID":"metadata-date","dfnText":"Date","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-date"}],"title":"4. Metadata"}],"url":"#metadata-date"},
-"metadata-deadline": {"dfnID":"metadata-deadline","dfnText":"Deadline","external":false,"refSections":[],"url":"#metadata-deadline"},
-"metadata-default-biblio-display": {"dfnID":"metadata-default-biblio-display","dfnText":"Default Biblio Display","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-default-biblio-display"}],"title":"8.1. Biblio Link Modifiers"}],"url":"#metadata-default-biblio-display"},
-"metadata-default-highlight": {"dfnID":"metadata-default-highlight","dfnText":"Default Highlight","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-default-highlight"}],"title":"5.6.3. Syntax Highlighting"}],"url":"#metadata-default-highlight"},
-"metadata-default-ref-status": {"dfnID":"metadata-default-ref-status","dfnText":"Default Ref Status","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-default-ref-status"}],"title":"8.1. Biblio Link Modifiers"}],"url":"#metadata-default-ref-status"},
-"metadata-die-on": {"dfnID":"metadata-die-on","dfnText":"Die On","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-die-on"}],"title":"3.1. Global Options"}],"url":"#metadata-die-on"},
-"metadata-die-when": {"dfnID":"metadata-die-when","dfnText":"Die When","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-die-when"}],"title":"3.1. Global Options"}],"url":"#metadata-die-when"},
-"metadata-ed": {"dfnID":"metadata-ed","dfnText":"ED","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-ed"}],"title":"12.2. Rearranging and Excluding \"Spec Metadata\""}],"url":"#metadata-ed"},
-"metadata-editor": {"dfnID":"metadata-editor","dfnText":"Editor","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-editor"},{"id":"ref-for-metadata-editor\u2460"}],"title":"4. Metadata"}],"url":"#metadata-editor"},
-"metadata-editor-term": {"dfnID":"metadata-editor-term","dfnText":"Editor Term","external":false,"refSections":[],"url":"#metadata-editor-term"},
-"metadata-expires": {"dfnID":"metadata-expires","dfnText":"Expires","external":false,"refSections":[],"url":"#metadata-expires"},
-"metadata-external-infotrees": {"dfnID":"metadata-external-infotrees","dfnText":"External Infotrees","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-external-infotrees"}],"title":"2.1. Using Curl"}],"url":"#metadata-external-infotrees"},
-"metadata-favicon": {"dfnID":"metadata-favicon","dfnText":"Favicon","external":false,"refSections":[],"url":"#metadata-favicon"},
-"metadata-force-crossorigin": {"dfnID":"metadata-force-crossorigin","dfnText":"Force Crossorigin","external":false,"refSections":[],"url":"#metadata-force-crossorigin"},
-"metadata-former-editor": {"dfnID":"metadata-former-editor","dfnText":"Former Editor","external":false,"refSections":[],"url":"#metadata-former-editor"},
-"metadata-group": {"dfnID":"metadata-group","dfnText":"Group","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-group"}],"title":"12.1. Groups"}],"url":"#metadata-group"},
-"metadata-h1": {"dfnID":"metadata-h1","dfnText":"H1","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-h1"},{"id":"ref-for-metadata-h1\u2460"}],"title":"4. Metadata"}],"url":"#metadata-h1"},
-"metadata-ignore-can-i-use-url-failure": {"dfnID":"metadata-ignore-can-i-use-url-failure","dfnText":"Ignore Can I Use URL Failure","external":false,"refSections":[],"url":"#metadata-ignore-can-i-use-url-failure"},
-"metadata-ignore-mdn-failure": {"dfnID":"metadata-ignore-mdn-failure","dfnText":"Ignore MDN Failure","external":false,"refSections":[],"url":"#metadata-ignore-mdn-failure"},
-"metadata-ignored-terms": {"dfnID":"metadata-ignored-terms","dfnText":"Ignored Terms","external":false,"refSections":[],"url":"#metadata-ignored-terms"},
-"metadata-ignored-vars": {"dfnID":"metadata-ignored-vars","dfnText":"Ignored Vars","external":false,"refSections":[],"url":"#metadata-ignored-vars"},
-"metadata-image-auto-size": {"dfnID":"metadata-image-auto-size","dfnText":"Image Auto Size","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-image-auto-size"}],"title":"5.13. Image Size Detection"}],"url":"#metadata-image-auto-size"},
-"metadata-include-can-i-use-panels": {"dfnID":"metadata-include-can-i-use-panels","dfnText":"Include Can I Use Panels","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-include-can-i-use-panels"}],"title":"4. Metadata"}],"url":"#metadata-include-can-i-use-panels"},
-"metadata-include-mdn-panels": {"dfnID":"metadata-include-mdn-panels","dfnText":"Include MDN Panels","external":false,"refSections":[],"url":"#metadata-include-mdn-panels"},
-"metadata-indent": {"dfnID":"metadata-indent","dfnText":"Indent","external":false,"refSections":[],"url":"#metadata-indent"},
-"metadata-infer-css-dfns": {"dfnID":"metadata-infer-css-dfns","dfnText":"Infer CSS Dfns","external":false,"refSections":[],"url":"#metadata-infer-css-dfns"},
-"metadata-informative-classes": {"dfnID":"metadata-informative-classes","dfnText":"Informative Classes","external":false,"refSections":[],"url":"#metadata-informative-classes"},
-"metadata-inline-github-issues": {"dfnID":"metadata-inline-github-issues","dfnText":"Inline Github Issues","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-inline-github-issues"}],"title":"3.2. bikeshed spec"}],"url":"#metadata-inline-github-issues"},
-"metadata-issue-class": {"dfnID":"metadata-issue-class","dfnText":"Issue Class","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-issue-class"}],"title":"5.2. Notes, Issues, Examples, Advisements"}],"url":"#metadata-issue-class"},
-"metadata-issue-tracker-template": {"dfnID":"metadata-issue-tracker-template","dfnText":"Issue Tracker Template","external":false,"refSections":[],"url":"#metadata-issue-tracker-template"},
-"metadata-issue-tracking": {"dfnID":"metadata-issue-tracking","dfnText":"Issue Tracking","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-issue-tracking"}],"title":"4. Metadata"}],"url":"#metadata-issue-tracking"},
-"metadata-level": {"dfnID":"metadata-level","dfnText":"Level","external":false,"refSections":[],"url":"#metadata-level"},
-"metadata-line-numbers": {"dfnID":"metadata-line-numbers","dfnText":"Line Numbers","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-line-numbers"}],"title":"5.6.4. Line Numbers"}],"url":"#metadata-line-numbers"},
-"metadata-link-defaults": {"dfnID":"metadata-link-defaults","dfnText":"Link Defaults","external":false,"refSections":[],"url":"#metadata-link-defaults"},
-"metadata-local-boilerplate": {"dfnID":"metadata-local-boilerplate","dfnText":"Local Boilerplate","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-local-boilerplate"}],"title":"2.1. Using Curl"}],"url":"#metadata-local-boilerplate"},
-"metadata-logo": {"dfnID":"metadata-logo","dfnText":"Logo","external":false,"refSections":[],"url":"#metadata-logo"},
-"metadata-mailing-list": {"dfnID":"metadata-mailing-list","dfnText":"Mailing List","external":false,"refSections":[],"url":"#metadata-mailing-list"},
-"metadata-mailing-list-archives": {"dfnID":"metadata-mailing-list-archives","dfnText":"Mailing List Archives","external":false,"refSections":[],"url":"#metadata-mailing-list-archives"},
-"metadata-markup-shorthands": {"dfnID":"metadata-markup-shorthands","dfnText":"Markup Shorthands","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-markup-shorthands"},{"id":"ref-for-metadata-markup-shorthands\u2460"}],"title":"4. Metadata"},{"refs":[{"id":"ref-for-metadata-markup-shorthands\u2461"}],"title":"5.4.1. \nAutolink Shortcuts That Work Anywhere: the l element"}],"url":"#metadata-markup-shorthands"},
-"metadata-max-toc-depth": {"dfnID":"metadata-max-toc-depth","dfnText":"Max ToC Depth","external":false,"refSections":[],"url":"#metadata-max-toc-depth"},
-"metadata-metadata-include": {"dfnID":"metadata-metadata-include","dfnText":"Metadata Include","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-metadata-include"},{"id":"ref-for-metadata-metadata-include\u2460"},{"id":"ref-for-metadata-metadata-include\u2461"}],"title":"12.2. Rearranging and Excluding \"Spec Metadata\""}],"url":"#metadata-metadata-include"},
-"metadata-metadata-order": {"dfnID":"metadata-metadata-order","dfnText":"Metadata Order","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-metadata-order"},{"id":"ref-for-metadata-metadata-order\u2460"}],"title":"12.2. Rearranging and Excluding \"Spec Metadata\""}],"url":"#metadata-metadata-order"},
-"metadata-no-abstract": {"dfnID":"metadata-no-abstract","dfnText":"No Abstract","external":false,"refSections":[],"url":"#metadata-no-abstract"},
-"metadata-no-editor": {"dfnID":"metadata-no-editor","dfnText":"No Editor","external":false,"refSections":[],"url":"#metadata-no-editor"},
-"metadata-note-class": {"dfnID":"metadata-note-class","dfnText":"Note Class","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-note-class"}],"title":"5.2. Notes, Issues, Examples, Advisements"}],"url":"#metadata-note-class"},
-"metadata-opaque-elements": {"dfnID":"metadata-opaque-elements","dfnText":"Opaque Elements","external":false,"refSections":[],"url":"#metadata-opaque-elements"},
-"metadata-prepare-for-tr": {"dfnID":"metadata-prepare-for-tr","dfnText":"Prepare For TR","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-prepare-for-tr"}],"title":"3.5.1. Testing Publication Locally"}],"url":"#metadata-prepare-for-tr"},
-"metadata-previous-version": {"dfnID":"metadata-previous-version","dfnText":"Previous Version","external":false,"refSections":[],"url":"#metadata-previous-version"},
-"metadata-remove-multiple-links": {"dfnID":"metadata-remove-multiple-links","dfnText":"Remove Multiple Links","external":false,"refSections":[],"url":"#metadata-remove-multiple-links"},
-"metadata-repository": {"dfnID":"metadata-repository","dfnText":"Repository","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-repository"},{"id":"ref-for-metadata-repository\u2460"}],"title":"4. Metadata"}],"url":"#metadata-repository"},
-"metadata-required-ids": {"dfnID":"metadata-required-ids","dfnText":"Required IDs","external":false,"refSections":[],"url":"#metadata-required-ids"},
-"metadata-revision": {"dfnID":"metadata-revision","dfnText":"Revision","external":false,"refSections":[],"url":"#metadata-revision"},
-"metadata-shortname": {"dfnID":"metadata-shortname","dfnText":"Shortname","external":false,"refSections":[],"url":"#metadata-shortname"},
-"metadata-slim-build-artifact": {"dfnID":"metadata-slim-build-artifact","dfnText":"Slim Build Artifact","external":false,"refSections":[],"url":"#metadata-slim-build-artifact"},
-"metadata-status": {"dfnID":"metadata-status","dfnText":"Status","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-status"}],"title":"4. Metadata"},{"refs":[{"id":"ref-for-metadata-status\u2460"}],"title":"12.4. Conditional Inclusion"}],"url":"#metadata-status"},
-"metadata-status-text": {"dfnID":"metadata-status-text","dfnText":"Status Text","external":false,"refSections":[],"url":"#metadata-status-text"},
-"metadata-test-suite": {"dfnID":"metadata-test-suite","dfnText":"Test Suite","external":false,"refSections":[],"url":"#metadata-test-suite"},
-"metadata-text-macro": {"dfnID":"metadata-text-macro","dfnText":"Text Macro","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-text-macro"}],"title":"4. Metadata"},{"refs":[{"id":"ref-for-metadata-text-macro\u2460"}],"title":"4.2. Computing Metadata From Other Metadata"},{"refs":[{"id":"ref-for-metadata-text-macro\u2461"}],"title":"12.4. Conditional Inclusion"}],"url":"#metadata-text-macro"},
-"metadata-title": {"dfnID":"metadata-title","dfnText":"Title","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-title"},{"id":"ref-for-metadata-title\u2460"}],"title":"4. Metadata"},{"refs":[{"id":"ref-for-metadata-title\u2461"}],"title":"4.4. Ordering Between Metadata Sources"}],"url":"#metadata-title"},
-"metadata-toggle-diffs": {"dfnID":"metadata-toggle-diffs","dfnText":"Toggle Diffs","external":false,"refSections":[],"url":"#metadata-toggle-diffs"},
-"metadata-tr": {"dfnID":"metadata-tr","dfnText":"TR","external":false,"refSections":[],"url":"#metadata-tr"},
-"metadata-tracking-vector-alt-text": {"dfnID":"metadata-tracking-vector-alt-text","dfnText":"Tracking Vector Alt Text","external":false,"refSections":[],"url":"#metadata-tracking-vector-alt-text"},
-"metadata-tracking-vector-class": {"dfnID":"metadata-tracking-vector-class","dfnText":"Tracking Vector Class","external":false,"refSections":[],"url":"#metadata-tracking-vector-class"},
-"metadata-tracking-vector-image": {"dfnID":"metadata-tracking-vector-image","dfnText":"Tracking Vector Image","external":false,"refSections":[],"url":"#metadata-tracking-vector-image"},
-"metadata-tracking-vector-image-height": {"dfnID":"metadata-tracking-vector-image-height","dfnText":"Tracking Vector Image Height","external":false,"refSections":[],"url":"#metadata-tracking-vector-image-height"},
-"metadata-tracking-vector-image-width": {"dfnID":"metadata-tracking-vector-image-width","dfnText":"Tracking Vector Image Width","external":false,"refSections":[],"url":"#metadata-tracking-vector-image-width"},
-"metadata-tracking-vector-title": {"dfnID":"metadata-tracking-vector-title","dfnText":"Tracking Vector Title","external":false,"refSections":[],"url":"#metadata-tracking-vector-title"},
-"metadata-translate-ids": {"dfnID":"metadata-translate-ids","dfnText":"Translate IDs","external":false,"refSections":[],"url":"#metadata-translate-ids"},
-"metadata-translation": {"dfnID":"metadata-translation","dfnText":"Translation","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-translation"}],"title":"3.6. bikeshed update"}],"url":"#metadata-translation"},
-"metadata-url": {"dfnID":"metadata-url","dfnText":"URL","external":false,"refSections":[],"url":"#metadata-url"},
-"metadata-use-dfn-panels": {"dfnID":"metadata-use-dfn-panels","dfnText":"Use Dfn Panels","external":false,"refSections":[],"url":"#metadata-use-dfn-panels"},
-"metadata-use-i-autolinks": {"dfnID":"metadata-use-i-autolinks","dfnText":"Use <i> Autolinks","external":false,"refSections":[],"url":"#metadata-use-i-autolinks"},
-"metadata-warning": {"dfnID":"metadata-warning","dfnText":"Warning","external":false,"refSections":[],"url":"#metadata-warning"},
-"metadata-work-status": {"dfnID":"metadata-work-status","dfnText":"Work Status","external":false,"refSections":[],"url":"#metadata-work-status"},
-"metadata-wpt-display": {"dfnID":"metadata-wpt-display","dfnText":"WPT Display","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-wpt-display"}],"title":"11.1. \nAnnotating Specs with Tests: the wpt element"}],"url":"#metadata-wpt-display"},
-"metadata-wpt-path-prefix": {"dfnID":"metadata-wpt-path-prefix","dfnText":"WPT Path Prefix","external":false,"refSections":[{"refs":[{"id":"ref-for-metadata-wpt-path-prefix"},{"id":"ref-for-metadata-wpt-path-prefix\u2460"},{"id":"ref-for-metadata-wpt-path-prefix\u2461"},{"id":"ref-for-metadata-wpt-path-prefix\u2462"}],"title":"11.1. \nAnnotating Specs with Tests: the wpt element"}],"url":"#metadata-wpt-path-prefix"},
-"propdef-flex-basis": {"dfnID":"propdef-flex-basis","dfnText":"flex-basis","external":false,"refSections":[],"url":"#propdef-flex-basis"},
-"railroad-and": {"dfnID":"railroad-and","dfnText":"And","external":false,"refSections":[],"url":"#railroad-and"},
-"railroad-c": {"dfnID":"railroad-c","dfnText":"C","external":false,"refSections":[],"url":"#railroad-c"},
-"railroad-choice": {"dfnID":"railroad-choice","dfnText":"Choice","external":false,"refSections":[{"refs":[{"id":"ref-for-railroad-choice"}],"title":"13.1. The Diagram Language"}],"url":"#railroad-choice"},
-"railroad-comment": {"dfnID":"railroad-comment","dfnText":"Comment","external":false,"refSections":[],"url":"#railroad-comment"},
-"railroad-n": {"dfnID":"railroad-n","dfnText":"N","external":false,"refSections":[],"url":"#railroad-n"},
-"railroad-nonterminal": {"dfnID":"railroad-nonterminal","dfnText":"NonTerminal","external":false,"refSections":[],"url":"#railroad-nonterminal"},
-"railroad-oneormore": {"dfnID":"railroad-oneormore","dfnText":"OneOrMore","external":false,"refSections":[{"refs":[{"id":"ref-for-railroad-oneormore"},{"id":"ref-for-railroad-oneormore\u2460"}],"title":"13.1. The Diagram Language"}],"url":"#railroad-oneormore"},
-"railroad-opt": {"dfnID":"railroad-opt","dfnText":"Opt","external":false,"refSections":[],"url":"#railroad-opt"},
-"railroad-optional": {"dfnID":"railroad-optional","dfnText":"Optional","external":false,"refSections":[{"refs":[{"id":"ref-for-railroad-optional"},{"id":"ref-for-railroad-optional\u2460"}],"title":"13.1. The Diagram Language"}],"url":"#railroad-optional"},
-"railroad-or": {"dfnID":"railroad-or","dfnText":"Or","external":false,"refSections":[],"url":"#railroad-or"},
-"railroad-plus": {"dfnID":"railroad-plus","dfnText":"Plus","external":false,"refSections":[],"url":"#railroad-plus"},
-"railroad-s": {"dfnID":"railroad-s","dfnText":"S","external":false,"refSections":[],"url":"#railroad-s"},
-"railroad-seq": {"dfnID":"railroad-seq","dfnText":"Seq","external":false,"refSections":[],"url":"#railroad-seq"},
-"railroad-sequence": {"dfnID":"railroad-sequence","dfnText":"Sequence","external":false,"refSections":[],"url":"#railroad-sequence"},
-"railroad-skip": {"dfnID":"railroad-skip","dfnText":"Skip","external":false,"refSections":[],"url":"#railroad-skip"},
-"railroad-stack": {"dfnID":"railroad-stack","dfnText":"Stack","external":false,"refSections":[],"url":"#railroad-stack"},
-"railroad-star": {"dfnID":"railroad-star","dfnText":"Star","external":false,"refSections":[],"url":"#railroad-star"},
-"railroad-t": {"dfnID":"railroad-t","dfnText":"T","external":false,"refSections":[],"url":"#railroad-t"},
-"railroad-terminal": {"dfnID":"railroad-terminal","dfnText":"Terminal","external":false,"refSections":[],"url":"#railroad-terminal"},
-"railroad-zeroormore": {"dfnID":"railroad-zeroormore","dfnText":"ZeroOrMore","external":false,"refSections":[{"refs":[{"id":"ref-for-railroad-zeroormore"}],"title":"13.1. The Diagram Language"}],"url":"#railroad-zeroormore"},
-"soft-boolish": {"dfnID":"soft-boolish","dfnText":"soft boolish","external":false,"refSections":[{"refs":[{"id":"ref-for-soft-boolish"},{"id":"ref-for-soft-boolish\u2460"}],"title":"4. Metadata"}],"url":"#soft-boolish"},
-"wpt-element": {"dfnID":"wpt-element","dfnText":"11.1. \nAnnotating Specs with Tests: the wpt element","external":false,"refSections":[{"refs":[{"id":"ref-for-wpt-element"},{"id":"ref-for-wpt-element\u2460"}],"title":"4. Metadata"},{"refs":[{"id":"ref-for-wpt-element\u2461"},{"id":"ref-for-wpt-element"},{"id":"ref-for-wpt-element\u2462"},{"id":"ref-for-wpt-element\u2463"},{"id":"ref-for-wpt-element\u2464"},{"id":"ref-for-wpt-element\u2465"},{"id":"ref-for-wpt-element\u2466"},{"id":"ref-for-wpt-element\u2467"},{"id":"ref-for-wpt-element\u2468"},{"id":"ref-for-wpt-element\u2460\u24ea"},{"id":"ref-for-wpt-element\u2460\u2460"},{"id":"ref-for-wpt-element\u2460\u2461"},{"id":"ref-for-wpt-element\u2460\u2462"},{"id":"ref-for-wpt-element\u2460\u2463"},{"id":"ref-for-wpt-element\u2460\u2464"},{"id":"ref-for-wpt-element\u2460\u2465"},{"id":"ref-for-wpt-element\u2460\u2466"},{"id":"ref-for-wpt-element\u2460\u2467"},{"id":"ref-for-wpt-element\u2460\u2468"},{"id":"ref-for-wpt-element\u2461\u24ea"}],"title":"11.1. \nAnnotating Specs with Tests: the wpt element"}],"url":"#wpt-element"},
-};
-
-document.addEventListener("DOMContentLoaded", ()=>{
-    genAllDfnPanels();
-
-    document.body.addEventListener("click", (e) => {
-        // If not handled already, just hide all dfn panels.
-        hideAllDfnPanels();
-    });
-});
-
-window.addEventListener("resize", () => {
-    // Pin any visible dfn panel
-    queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>positionDfnPanel(el));
-});
-
-function genAllDfnPanels() {
-    for(const panelData of Object.values(dfnPanelData)) {
-        const dfnID = panelData.dfnID;
-        const dfn = document.getElementById(dfnID);
-        if(!dfn) {
-            console.log(`Can't find dfn#${dfnID}.`, panelData);
-            continue;
-        }
-        dfn.panelData = panelData;
-        insertDfnPopupAction(dfn);
-    }
-}
-
-function genDfnPanel(dfn, { dfnID, url, dfnText, refSections, external }) {
-    const dfnPanel = mk.aside({
-        class: "dfn-panel on",
-        id: `infopanel-for-${dfnID}`,
-        "data-for": dfnID,
-        "aria-labelled-by":`infopaneltitle-for-${dfnID}`,
-        },
-        mk.span({id:`infopaneltitle-for-${dfnID}`, style:"display:none"},
-            `Info about the '${dfnText}' ${external?"external":""} reference.`),
-        mk.a({href:url, class:"dfn-link"}, url),
-        refSections.length == 0 ? [] :
-            mk.b({}, "Referenced in:"),
-            mk.ul({},
-                ...refSections.map(section=>
-                    mk.li({},
-                        ...section.refs.map((ref, refI)=>
-                            [
-                                mk.a({ href: `#${ref.id}` },
-                                    (refI == 0) ? section.title : `(${refI + 1})`
-                                ),
-                                " ",
-                            ]
-                        ),
-                    ),
-                ),
-            ),
-        genLinkingSyntaxes(dfn),
-    );
-
-    dfnPanel.addEventListener('click', (event) => {
-        if (event.target.nodeName == 'A') {
-            scrollToTargetAndHighlight(event);
-            pinDfnPanel(dfnPanel);
-        }
-        event.stopPropagation();
-        refocusOnTarget(event);
-    });
-    dfnPanel.addEventListener('keydown', (event) => {
-        if(event.keyCode == 27) { // Escape key
-            hideDfnPanel({dfnPanel});
-            event.stopPropagation();
-            event.preventDefault();
-        }
-    });
-
-    dfnPanel.dfn = dfn;
-    dfn.dfnPanel = dfnPanel;
-    return dfnPanel;
-}
-
-
-
-function hideAllDfnPanels() {
-    // Delete the currently-active dfn panel.
-    queryAll(".dfn-panel").forEach(dfnPanel=>hideDfnPanel({dfnPanel}));
-}
-
-function showDfnPanel(dfn) {
-    hideAllDfnPanels(); // Only display one at a time.
-
-    dfn.setAttribute("aria-expanded", "true");
-
-    const dfnPanel = genDfnPanel(dfn, dfn.panelData);
-
-    // Give the dfn a unique tabindex, and then
-    // give all the tabbable panel bits successive indexes.
-    let tabIndex = 100;
-    dfn.tabIndex = tabIndex++;
-    const tabbable = dfnPanel.querySelectorAll(":is(a, button)");
-    for (const el of tabbable) {
-        el.tabIndex = tabIndex++;
-    }
-
-    append(document.body, dfnPanel);
-    positionDfnPanel(dfnPanel);
-}
-
-function positionDfnPanel(dfnPanel) {
-    const dfn = dfnPanel.dfn;
-    const dfnPos = getRootLevelAbsolutePosition(dfn);
-    dfnPanel.style.top = dfnPos.bottom + "px";
-    dfnPanel.style.left = dfnPos.left + "px";
-
-    const panelPos = dfnPanel.getBoundingClientRect();
-    const panelMargin = 8;
-    const maxRight = document.body.parentNode.clientWidth - panelMargin;
-    if (panelPos.right > maxRight) {
-        const overflowAmount = panelPos.right - maxRight;
-        const newLeft = Math.max(panelMargin, dfnPos.left - overflowAmount);
-        dfnPanel.style.left = newLeft + "px";
-    }
-}
-
-function pinDfnPanel(dfnPanel) {
-    // Switch it to "activated" state, which pins it.
-    dfnPanel.classList.add("activated");
-    dfnPanel.style.position = "fixed";
-    dfnPanel.style.left = null;
-    dfnPanel.style.top = null;
-}
-
-function hideDfnPanel({dfn, dfnPanel}) {
-    if(!dfnPanel) dfnPanel = dfn.dfnPanel;
-    if(!dfn) dfn = dfnPanel.dfn;
-    dfn.dfnPanel = undefined;
-    dfnPanel.dfn = undefined;
-    dfn.setAttribute("aria-expanded", "false");
-    dfn.tabIndex = undefined;
-    dfnPanel.remove()
-}
-
-function toggleDfnPanel(dfn) {
-    if(dfn.dfnPanel) {
-        hideDfnPanel(dfn);
-    } else {
-        showDfnPanel(dfn);
-    }
-}
-
-function insertDfnPopupAction(dfn) {
-    dfn.setAttribute('role', 'button');
-    dfn.setAttribute('aria-expanded', 'false')
-    dfn.tabIndex = 0;
-    dfn.classList.add('has-dfn-panel');
-    dfn.addEventListener('click', (event) => {
-        toggleDfnPanel(dfn);
-        event.stopPropagation();
-    });
-    dfn.addEventListener('keypress', (event) => {
-        const kc = event.keyCode;
-        // 32->Space, 13->Enter
-        if(kc == 32 || kc == 13) {
-            toggleDfnPanel(dfn);
-            event.stopPropagation();
-            event.preventDefault();
-        }
-    });
-}
-
-function refocusOnTarget(event) {
-    const target = event.target;
-    setTimeout(() => {
-        // Refocus on the event.target element.
-        // This is needed after browser scrolls to the destination.
-        target.focus();
-    });
-}
-
-// Returns the root-level absolute position {left and top} of element.
-function getRootLevelAbsolutePosition(el) {
-    const boundsRect = el.getBoundingClientRect();
-    let xPos = 0;
-    let yPos = 0;
-
-    while (el) {
-        let xScroll = el.scrollLeft;
-        let yScroll = el.scrollTop;
-
-        // Ignore scrolling of body.
-        if (el.tagName === "BODY") {
-            xScroll = 0;
-            yScroll = 0;
-        }
-        xPos += (el.offsetLeft - xScroll + el.clientLeft);
-        yPos += (el.offsetTop - yScroll + el.clientTop);
-
-        el = el.offsetParent;
-    }
-    return {
-        left: xPos,
-        top: yPos,
-        right: xPos + boundsRect.width,
-        bottom: yPos + boundsRect.height,
-    };
-}
-
-function scrolledIntoView(element) {
-    const rect = element.getBoundingClientRect();
-    return (
-        rect.top > 0 &&
-        rect.bottom < window.innerHeight
-    );
-}
-
-function scrollToTargetAndHighlight(event) {
-    let hash = event.target.hash;
-    if (hash) {
-        hash = decodeURIComponent(hash.substring(1));
-        const dest = document.getElementById(hash);
-        if (dest) {
-            // Maybe prevent default scroll.
-            if (scrolledIntoView(dest)) {
-                event.preventDefault();
-            }
-            dest.classList.add('highlighted');
-            setTimeout(() => dest.classList.remove('highlighted'), 1000);
-        }
-    }
-}
-
-// Functions, divided by link type, that wrap an autolink's
-// contents with the appropriate outer syntax.
-// Alternately, a string naming another type they format
-// the same as.
-function needsFor(type) {
-    switch(type) {
-        case "descriptor":
-        case "value":
-        case "element-attr":
-        case "attr-value":
-        case "element-state":
-        case "method":
-        case "constructor":
-        case "argument":
-        case "attribute":
-        case "const":
-        case "dict-member":
-        case "event":
-        case "enum-value":
-        case "stringifier":
-        case "serializer":
-        case "iterator":
-        case "maplike":
-        case "setlike":
-        case "state":
-        case "mode":
-        case "context":
-        case "facet": return true;
-
-        default: return false;
-    }
-}
-function refusesFor(type) {
-    switch(type) {
-        case "property":
-        case "element":
-        case "interface":
-        case "namespace":
-        case "callback":
-        case "dictionary":
-        case "enum":
-        case "exception":
-        case "typedef":
-        case "http-header":
-        case "permission": return true;
-
-        default: return false;
-    }
-}
-function linkFormatterFromType(type) {
-    switch(type) {
-        case 'scheme':
-        case 'permission':
-        case 'dfn': return (text) => `[=${text}=]`;
-
-        case 'abstract-op': return (text) => `[\$${text}\$]`;
-
-        case 'function':
-        case 'at-rule':
-        case 'selector':
-        case 'value': return (text) => `''${text}''`;
-
-        case 'http-header': return (text) => `[:${text}:]`;
-
-        case 'interface':
-        case 'constructor':
-        case 'method':
-        case 'argument':
-        case 'attribute':
-        case 'callback':
-        case 'dictionary':
-        case 'dict-member':
-        case 'enum':
-        case 'enum-value':
-        case 'exception':
-        case 'const':
-        case 'typedef':
-        case 'stringifier':
-        case 'serializer':
-        case 'iterator':
-        case 'maplike':
-        case 'setlike':
-        case 'extended-attribute':
-        case 'event':
-        case 'idl': return (text) => `{{${text}}}`;
-
-        case 'element-state':
-        case 'element-attr':
-        case 'attr-value':
-        case 'element': return (element) => `<{${element}}>`;
-
-        case 'grammar': return (text) => `${text} (within a <pre class=prod>)`;
-
-        case 'type': return (text)=> `<<${text}>>`;
-
-        case 'descriptor':
-        case 'property': return (text) => `'${text}'`;
-
-        default: return;
-    };
-};
-
-function genLinkingSyntaxes(dfn) {
-    if(dfn.tagName != "DFN") return;
-
-    const type = dfn.getAttribute('data-dfn-type');
-    if(!type) {
-        console.log(`<dfn> doesn't have a data-dfn-type:`, dfn);
-        return [];
-    }
-
-    // Return a function that wraps link text based on the type
-    const linkFormatter = linkFormatterFromType(type);
-    if(!linkFormatter) {
-        console.log(`<dfn> has an unknown data-dfn-type:`, dfn);
-        return [];
-    }
-
-    let ltAlts;
-    if(dfn.hasAttribute('data-lt')) {
-        ltAlts = dfn.getAttribute('data-lt')
-            .split("|")
-            .map(x=>x.trim());
-    } else {
-        ltAlts = [dfn.textContent.trim()];
-    }
-    if(type == "type") {
-        // lt of "<foo>", but "foo" is the interior;
-        // <<foo/bar>> is how you write it with a for,
-        // not <foo/<bar>> or whatever.
-        for(var i = 0; i < ltAlts.length; i++) {
-            const lt = ltAlts[i];
-            const match = /<(.*)>/.exec(lt);
-            if(match) { ltAlts[i] = match[1]; }
-        }
-    }
-
-    let forAlts;
-    if(dfn.hasAttribute('data-dfn-for')) {
-        forAlts = dfn.getAttribute('data-dfn-for')
-            .split(",")
-            .map(x=>x.trim());
-    } else {
-        forAlts = [''];
-    }
-
-    let linkingSyntaxes = [];
-    if(!needsFor(type)) {
-        for(const lt of ltAlts) {
-            linkingSyntaxes.push(linkFormatter(lt));
-        }
-    }
-    if(!refusesFor(type)) {
-        for(const f of forAlts) {
-            linkingSyntaxes.push(linkFormatter(`${f}/${ltAlts[0]}`))
-        }
-    }
-    return [
-        mk.b({}, 'Possible linking syntaxes:'),
-        mk.ul({},
-            ...linkingSyntaxes.map(link => {
-                const copyLink = async () =>
-                    await navigator.clipboard.writeText(link);
-                return mk.li({},
-                    mk.div({ class: 'link-item' },
-                        mk.button({
-                            class: 'copy-icon', title: 'Copy',
-                            type: 'button',
-                            _onclick: copyLink,
-                            tabindex: 0,
-                        }, mk.span({ class: 'icon' }) ),
-                        mk.span({}, link)
-                    )
-                );
-            })
-        )
-    ];
-}
-}
-</script>
-<script>/* Boilerplate: script-ref-hints */
-"use strict";
-{
-let refsData = {
-"#algorithms": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"algorithms","type":"dfn","url":"#algorithms"},
-"#biblio-autolink": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"biblio autolink","type":"dfn","url":"#biblio-autolink"},
-"#boolish": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"boolish","type":"dfn","url":"#boolish"},
-"#dfn-autolink": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"dfn autolink","type":"dfn","url":"#dfn-autolink"},
-"#dom-foo-bar": {"export":true,"for_":["Foo"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"bar(arg1, arg2)","type":"method","url":"#dom-foo-bar"},
-"#element-attrdef-global-exclude-if": {"export":true,"for_":["global"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"exclude-if","type":"element-attr","url":"#element-attrdef-global-exclude-if"},
-"#element-attrdef-global-include-if": {"export":true,"for_":["global"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"include-if","type":"element-attr","url":"#element-attrdef-global-include-if"},
-"#element-attrdef-wpt-pathprefix": {"export":true,"for_":["wpt","wpt-rest"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"pathprefix","type":"element-attr","url":"#element-attrdef-wpt-pathprefix"},
-"#elementdef-if-wrapper": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"if-wrapper","type":"element","url":"#elementdef-if-wrapper"},
-"#elementdef-wpt-rest": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"wpt-rest","type":"element","url":"#elementdef-wpt-rest"},
-"#l-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"l","type":"element","url":"#l-element"},
-"#macro-date": {"export":true,"for_":["macro"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"[date]","type":"dfn","url":"#macro-date"},
-"#manual-autolink": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"manual autolink","type":"dfn","url":"#manual-autolink"},
-"#metadata-abstract": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"abstract","type":"dfn","url":"#metadata-abstract"},
-"#metadata-advisement-class": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"advisement class","type":"dfn","url":"#metadata-advisement-class"},
-"#metadata-assertion-class": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"assertion class","type":"dfn","url":"#metadata-assertion-class"},
-"#metadata-assume-explicit-for": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"assume explicit for","type":"dfn","url":"#metadata-assume-explicit-for"},
-"#metadata-boilerplate": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"boilerplate","type":"dfn","url":"#metadata-boilerplate"},
-"#metadata-can-i-use-url": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"can i use url","type":"dfn","url":"#metadata-can-i-use-url"},
-"#metadata-custom-warning-text": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"custom warning text","type":"dfn","url":"#metadata-custom-warning-text"},
-"#metadata-custom-warning-title": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"custom warning title","type":"dfn","url":"#metadata-custom-warning-title"},
-"#metadata-date": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"date","type":"dfn","url":"#metadata-date"},
-"#metadata-default-biblio-display": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"default biblio display","type":"dfn","url":"#metadata-default-biblio-display"},
-"#metadata-default-highlight": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"default highlight","type":"dfn","url":"#metadata-default-highlight"},
-"#metadata-default-ref-status": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"default ref status","type":"dfn","url":"#metadata-default-ref-status"},
-"#metadata-die-on": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"die on","type":"dfn","url":"#metadata-die-on"},
-"#metadata-die-when": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"die when","type":"dfn","url":"#metadata-die-when"},
-"#metadata-ed": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"ed","type":"dfn","url":"#metadata-ed"},
-"#metadata-editor": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"editor","type":"dfn","url":"#metadata-editor"},
-"#metadata-external-infotrees": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"external infotrees","type":"dfn","url":"#metadata-external-infotrees"},
-"#metadata-group": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"group","type":"dfn","url":"#metadata-group"},
-"#metadata-h1": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"h1","type":"dfn","url":"#metadata-h1"},
-"#metadata-image-auto-size": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"image auto size","type":"dfn","url":"#metadata-image-auto-size"},
-"#metadata-include-can-i-use-panels": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"include can i use panels","type":"dfn","url":"#metadata-include-can-i-use-panels"},
-"#metadata-inline-github-issues": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"inline github issues","type":"dfn","url":"#metadata-inline-github-issues"},
-"#metadata-issue-class": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"issue class","type":"dfn","url":"#metadata-issue-class"},
-"#metadata-issue-tracking": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"issue tracking","type":"dfn","url":"#metadata-issue-tracking"},
-"#metadata-line-numbers": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"line numbers","type":"dfn","url":"#metadata-line-numbers"},
-"#metadata-local-boilerplate": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"local boilerplate","type":"dfn","url":"#metadata-local-boilerplate"},
-"#metadata-markup-shorthands": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"markup shorthands","type":"dfn","url":"#metadata-markup-shorthands"},
-"#metadata-metadata-include": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"metadata include","type":"dfn","url":"#metadata-metadata-include"},
-"#metadata-metadata-order": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"metadata order","type":"dfn","url":"#metadata-metadata-order"},
-"#metadata-note-class": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"note class","type":"dfn","url":"#metadata-note-class"},
-"#metadata-prepare-for-tr": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"prepare for tr","type":"dfn","url":"#metadata-prepare-for-tr"},
-"#metadata-repository": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"repository","type":"dfn","url":"#metadata-repository"},
-"#metadata-status": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"status","type":"dfn","url":"#metadata-status"},
-"#metadata-text-macro": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"text macro","type":"dfn","url":"#metadata-text-macro"},
-"#metadata-title": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"title","type":"dfn","url":"#metadata-title"},
-"#metadata-translation": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"translation","type":"dfn","url":"#metadata-translation"},
-"#metadata-wpt-display": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"wpt display","type":"dfn","url":"#metadata-wpt-display"},
-"#metadata-wpt-path-prefix": {"export":true,"for_":["metadata"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"wpt path prefix","type":"dfn","url":"#metadata-wpt-path-prefix"},
-"#propdef-flex-basis": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"flex-basis","type":"property","url":"#propdef-flex-basis"},
-"#railroad-choice": {"export":true,"for_":["railroad"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"choice","type":"dfn","url":"#railroad-choice"},
-"#railroad-oneormore": {"export":true,"for_":["railroad"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"oneormore","type":"dfn","url":"#railroad-oneormore"},
-"#railroad-optional": {"export":true,"for_":["railroad"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"optional","type":"dfn","url":"#railroad-optional"},
-"#railroad-zeroormore": {"export":true,"for_":["railroad"],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"zeroormore","type":"dfn","url":"#railroad-zeroormore"},
-"#soft-boolish": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"soft boolish","type":"dfn","url":"#soft-boolish"},
-"#wpt-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"bikeshed","spec":"bikeshed-1","status":"local","text":"wpt","type":"element","url":"#wpt-element"},
-"https://drafts.csswg.org/css-flexbox-1/#flex-container": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"css-flexbox","spec":"css-flexbox-1","status":"current","text":"flex container","type":"dfn","url":"https://drafts.csswg.org/css-flexbox-1/#flex-container"},
-"https://drafts.csswg.org/css-flexbox-1/#flex-item": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"css-flexbox","spec":"css-flexbox-1","status":"current","text":"flex item","type":"dfn","url":"https://drafts.csswg.org/css-flexbox-1/#flex-item"},
-"https://drafts.csswg.org/css-flexbox-1/#main-size": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"css-flexbox","spec":"css-flexbox-1","status":"current","text":"main size","type":"dfn","url":"https://drafts.csswg.org/css-flexbox-1/#main-size"},
-"https://drafts.csswg.org/css-logical-1/#logical-property-group": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"css-logical","spec":"css-logical-1","status":"current","text":"logical property group","type":"dfn","url":"https://drafts.csswg.org/css-logical-1/#logical-property-group"},
-"https://drafts.csswg.org/web-animations-1/#animation-type": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"web-animations","spec":"web-animations-1","status":"current","text":"animation type","type":"dfn","url":"https://drafts.csswg.org/web-animations-1/#animation-type"},
-"https://html.spec.whatwg.org/multipage/dom.html#attr-dir": {"export":true,"for_":["html-global"],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"dir","type":"element-attr","url":"https://html.spec.whatwg.org/multipage/dom.html#attr-dir"},
-"https://html.spec.whatwg.org/multipage/dom.html#attr-lang": {"export":true,"for_":["html-global"],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"lang","type":"element-attr","url":"https://html.spec.whatwg.org/multipage/dom.html#attr-lang"},
-"https://html.spec.whatwg.org/multipage/dom.html#attr-title": {"export":true,"for_":["html-global"],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"title","type":"element-attr","url":"https://html.spec.whatwg.org/multipage/dom.html#attr-title"},
-"https://html.spec.whatwg.org/multipage/edits.html#the-del-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"del","type":"element","url":"https://html.spec.whatwg.org/multipage/edits.html#the-del-element"},
-"https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-height": {"export":true,"for_":["img","iframe","embed","object","source","video"],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"height","type":"element-attr","url":"https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-height"},
-"https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-width": {"export":true,"for_":["img","iframe","embed","object","source","video"],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"width","type":"element-attr","url":"https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-width"},
-"https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-src": {"export":true,"for_":["img"],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"src","type":"element-attr","url":"https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-src"},
-"https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset": {"export":true,"for_":["img"],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"srcset","type":"element-attr","url":"https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset"},
-"https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"img","type":"element","url":"https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element"},
-"https://html.spec.whatwg.org/multipage/grouping-content.html#the-dd-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"dd","type":"element","url":"https://html.spec.whatwg.org/multipage/grouping-content.html#the-dd-element"},
-"https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"dl","type":"element","url":"https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element"},
-"https://html.spec.whatwg.org/multipage/grouping-content.html#the-dt-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"dt","type":"element","url":"https://html.spec.whatwg.org/multipage/grouping-content.html#the-dt-element"},
-"https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"pre","type":"element","url":"https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element"},
-"https://html.spec.whatwg.org/multipage/images.html#image-source": {"export":false,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"image source","type":"dfn","url":"https://html.spec.whatwg.org/multipage/images.html#image-source"},
-"https://html.spec.whatwg.org/multipage/images.html#pixel-density-descriptor": {"export":false,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"pixel density descriptor","type":"dfn","url":"https://html.spec.whatwg.org/multipage/images.html#pixel-density-descriptor"},
-"https://html.spec.whatwg.org/multipage/input.html#the-input-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"input","type":"element","url":"https://html.spec.whatwg.org/multipage/input.html#the-input-element"},
-"https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden": {"export":true,"for_":["html-global"],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"hidden","type":"element-attr","url":"https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden"},
-"https://html.spec.whatwg.org/multipage/media.html#audio": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"audio","type":"element","url":"https://html.spec.whatwg.org/multipage/media.html#audio"},
-"https://html.spec.whatwg.org/multipage/media.html#video": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"video","type":"element","url":"https://html.spec.whatwg.org/multipage/media.html#video"},
-"https://html.spec.whatwg.org/multipage/obsolete.html#xmp": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"xmp","type":"element","url":"https://html.spec.whatwg.org/multipage/obsolete.html#xmp"},
-"https://html.spec.whatwg.org/multipage/scripting.html#script": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"script","type":"element","url":"https://html.spec.whatwg.org/multipage/scripting.html#script"},
-"https://html.spec.whatwg.org/multipage/sections.html#the-body-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"body","type":"element","url":"https://html.spec.whatwg.org/multipage/sections.html#the-body-element"},
-"https://html.spec.whatwg.org/multipage/sections.html#the-h1-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"h1","type":"element","url":"https://html.spec.whatwg.org/multipage/sections.html#the-h1-element"},
-"https://html.spec.whatwg.org/multipage/sections.html#the-h2-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"h2","type":"element","url":"https://html.spec.whatwg.org/multipage/sections.html#the-h2-element"},
-"https://html.spec.whatwg.org/multipage/sections.html#the-h6-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"h6","type":"element","url":"https://html.spec.whatwg.org/multipage/sections.html#the-h6-element"},
-"https://html.spec.whatwg.org/multipage/sections.html#the-section-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"section","type":"element","url":"https://html.spec.whatwg.org/multipage/sections.html#the-section-element"},
-"https://html.spec.whatwg.org/multipage/semantics.html#the-head-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"head","type":"element","url":"https://html.spec.whatwg.org/multipage/semantics.html#the-head-element"},
-"https://html.spec.whatwg.org/multipage/semantics.html#the-link-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"link","type":"element","url":"https://html.spec.whatwg.org/multipage/semantics.html#the-link-element"},
-"https://html.spec.whatwg.org/multipage/semantics.html#the-style-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"style","type":"element","url":"https://html.spec.whatwg.org/multipage/semantics.html#the-style-element"},
-"https://html.spec.whatwg.org/multipage/semantics.html#the-title-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"title","type":"element","url":"https://html.spec.whatwg.org/multipage/semantics.html#the-title-element"},
-"https://html.spec.whatwg.org/multipage/tables.html#the-table-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"table","type":"element","url":"https://html.spec.whatwg.org/multipage/tables.html#the-table-element"},
-"https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"a","type":"element","url":"https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"},
-"https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-code-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"code","type":"element","url":"https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-code-element"},
-"https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"dfn","type":"element","url":"https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element"},
-"https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-i-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"i","type":"element","url":"https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-i-element"},
-"https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"span","type":"element","url":"https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element"},
-"https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-var-element": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"var","type":"element","url":"https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-var-element"},
-"https://infra.spec.whatwg.org/#tracking-vector": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"tracking vector","type":"dfn","url":"https://infra.spec.whatwg.org/#tracking-vector"},
-"https://svgwg.org/svg2-draft/struct.html#elementdef-svg": {"export":true,"for_":[],"level":"2","normative":true,"shortname":"svg","spec":"svg2","status":"current","text":"svg","type":"element","url":"https://svgwg.org/svg2-draft/struct.html#elementdef-svg"},
-"https://webidl.spec.whatwg.org/#idl-DOMString": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"DOMString","type":"interface","url":"https://webidl.spec.whatwg.org/#idl-DOMString"},
-"https://webidl.spec.whatwg.org/#idl-long": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"long","type":"interface","url":"https://webidl.spec.whatwg.org/#idl-long"},
-"https://webidl.spec.whatwg.org/#idl-undefined": {"export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"undefined","type":"interface","url":"https://webidl.spec.whatwg.org/#idl-undefined"},
-};
-
-function mkRefHint(link, ref) {
-    const linkText = link.textContent;
-    let dfnTextElements = '';
-    if (ref.text != linkText) {
-        dfnTextElements =
-            mk.li({},
-                mk.b({}, "Term: "),
-                mk.span({}, ref.text)
-            );
-    }
-    const forList = ref.for_;
-    let forListElements;
-    if(forList.length == 0) {
-        forListElements = [];
-    } else if(forList.length == 1) {
-        forListElements = mk.li({},
-            mk.b({}, "For: "),
-            mk.span({}, forList[0]),
-        );
-    } else {
-        forListElements = mk.li({},
-            mk.b({}, "For: "),
-            mk.ul({},
-                ...forList.map(forItem =>
-                    mk.li({},
-                        mk.span({}, forItem)
-                    ),
-                ),
-            ),
-        );
-    }
-    const url = ref.url;
-    const safeUrl = encodeURIComponent(url);
-    const hintPanel = mk.aside({
-        class: "ref-hint",
-        id: `ref-hint-for-${safeUrl}`,
-        "data-for": url,
-        "aria-labelled-by": `ref-hint-for-${safeUrl}`,
-    },
-        mk.ul({},
-            dfnTextElements,
-            mk.li({},
-                mk.b({}, "URL: "),
-                mk.a({ href: url, class: "ref" }, url),
-            ),
-            mk.li({},
-                mk.b({}, "Type: "),
-                mk.span({}, `${ref.type}`),
-            ),
-            mk.li({},
-                mk.b({}, "Spec: "),
-                mk.span({}, `${ref.spec ? ref.spec : ''}`),
-            ),
-            forListElements
-        ),
-    );
-    hintPanel.forLink = link;
-    setupRefHintEventListeners(link, hintPanel);
-    return hintPanel;
-}
-
-function hideAllRefHints() {
-    queryAll(".ref-hint").forEach(el=>hideRefHint(el));
-}
-
-function hideRefHint(refHint) {
-    const link = refHint.forLink;
-    link.setAttribute("aria-expanded", "false");
-    if(refHint.teardownEventListeners) {
-        refHint.teardownEventListeners();
-    }
-    refHint.remove();
-}
-
-function showRefHint(link) {
-    if(link.classList.contains("dfn-link")) return;
-    const url = link.getAttribute("href");
-    const ref = refsData[url];
-    if(!ref) return;
-
-    hideAllRefHints(); // Only display one at this time.
-
-    const refHint = mkRefHint(link, ref);
-    append(document.body, refHint);
-    link.setAttribute("aria-expanded", "true");
-    positionRefHint(refHint);
-}
-
-function setupRefHintEventListeners(link, refHint) {
-    if (refHint.teardownEventListeners) return;
-    // Add event handlers to hide the refHint after the user moves away
-    // from both the link and refHint, if not hovering either within one second.
-    let timeout = null;
-    const startHidingRefHint = (event) => {
-        if (timeout) {
-            clearTimeout(timeout);
-        }
-        timeout = setTimeout(() => {
-            hideRefHint(refHint);
-        }, 1000);
-    }
-    const resetHidingRefHint = (event) => {
-        if (timeout) clearTimeout(timeout);
-        timeout = null;
-    };
-    link.addEventListener("mouseleave", startHidingRefHint);
-    link.addEventListener("mouseenter", resetHidingRefHint);
-    link.addEventListener("blur", startHidingRefHint);
-    link.addEventListener("focus", resetHidingRefHint);
-    refHint.addEventListener("mouseleave", startHidingRefHint);
-    refHint.addEventListener("mouseenter", resetHidingRefHint);
-    refHint.addEventListener("blur", startHidingRefHint);
-    refHint.addEventListener("focus", resetHidingRefHint);
-
-    refHint.teardownEventListeners = () => {
-        // remove event listeners
-        resetHidingRefHint();
-        link.removeEventListener("mouseleave", startHidingRefHint);
-        link.removeEventListener("mouseenter", resetHidingRefHint);
-        link.removeEventListener("blur", startHidingRefHint);
-        link.removeEventListener("focus", resetHidingRefHint);
-        refHint.removeEventListener("mouseleave", startHidingRefHint);
-        refHint.removeEventListener("mouseenter", resetHidingRefHint);
-        refHint.removeEventListener("blur", startHidingRefHint);
-        refHint.removeEventListener("focus", resetHidingRefHint);
-    };
-}
-
-function positionRefHint(refHint) {
-    const link = refHint.forLink;
-    const linkPos = getRootLevelAbsolutePosition(link);
-    refHint.style.top = linkPos.bottom + "px";
-    refHint.style.left = linkPos.left + "px";
-
-    const panelPos = refHint.getBoundingClientRect();
-    const panelMargin = 8;
-    const maxRight = document.body.parentNode.clientWidth - panelMargin;
-    if (panelPos.right > maxRight) {
-        const overflowAmount = panelPos.right - maxRight;
-        const newLeft = Math.max(panelMargin, linkPos.left - overflowAmount);
-        refHint.style.left = newLeft + "px";
-    }
-}
-
-// TODO: shared util
-// Returns the root-level absolute position {left and top} of element.
-function getRootLevelAbsolutePosition(el) {
-    const boundsRect = el.getBoundingClientRect();
-    let xPos = 0;
-    let yPos = 0;
-
-    while (el) {
-        let xScroll = el.scrollLeft;
-        let yScroll = el.scrollTop;
-
-        // Ignore scrolling of body.
-        if (el.tagName === "BODY") {
-            xScroll = 0;
-            yScroll = 0;
-        }
-        xPos += (el.offsetLeft - xScroll + el.clientLeft);
-        yPos += (el.offsetTop - yScroll + el.clientTop);
-
-        el = el.offsetParent;
-    }
-    return {
-        left: xPos,
-        top: yPos,
-        right: xPos + boundsRect.width,
-        bottom: yPos + boundsRect.height,
-    };
-}
-
-document.addEventListener("DOMContentLoaded", () => {
-    document.body.addEventListener("mouseover", e=>{
-        let link = e.target.closest("a");
-        if(link) showRefHint(link);
-    });
-    document.body.addEventListener("focus", e=>{
-        let link = e.target.closest("a");
-        if(link) showRefHint(link);
-    });
-
-    document.body.addEventListener("click", (e) => {
-        // If not handled already, just hide all link panels.
-        hideAllRefHints();
-    });
-});
-
-window.addEventListener("resize", () => {
-    // Hide any open ref hint.
-    hideAllRefHints();
-});
 }
 </script>
   <svg style="display:none" viewBox="0 0 46 64">


### PR DESCRIPTION
This PR would fix #2644 and #2645. Links to pubrules in cases where this is required.

Contributing requires the html to be generated. This has a bunch of fatal errors, which I didn't introduce, so I used -f.

```
chris@SuperNomad:/mnt/c/Users/chris/Documents/GitHub/mybikeshed/docs$ bikeshed -f spec
FATAL ERROR: Found unmatched text macro [LOGO]. Correct the macro, or escape it with a leading backslash.
FATAL ERROR: Found unmatched text macro [WORKSTATUS]. Correct the macro, or escape it with a leading backslash.
FATAL ERROR: Found unmatched text macro [FOO]. Correct the macro, or escape it with a leading backslash.
FATAL ERROR: Found unmatched text macro [BAZ]. Correct the macro, or escape it with a leading backslash.
FATAL ERROR: Found unmatched text macro [H1]. Correct the macro, or escape it with a leading backslash.
FATAL ERROR: Found unmatched text macro [LATEST]. Correct the macro, or escape it with a leading backslash.
FATAL ERROR: Found unmatched text macro [ABSTRACTATTR]. Correct the macro, or escape it with a leading backslash.
FATAL ERROR: Found unmatched text macro [DEADLINE]. Correct the macro, or escape it with a leading backslash.
LINE 4114: Dfn has no linking text:
<dfn bs-line-number="4114"><code bs-line-number="4114" bs-autolink-syntax="``" bs-opaque=""></code></dfn>
LINE 4117: Dfn has no linking text:
<dfn bs-line-number="4117"><code bs-line-number="4117" bs-autolink-syntax="`&lt;p bs-line-number=-1&gt;Bikeshed is a spec-generating tool that takes in lightly-decorated Markdown and spits out a full spec, with cross-spec autolinking, automatic generation of indexes/ToC/etc, and many other features.&lt;/p&gt;
`" bs-opaque=""></code></dfn>
LINE 4120: Multiple elements have the same ID 'macro-13-january-2024'.
Deduping, but this ID may not be stable across revisions.
LINE 4120: Multiple local 'dfn' <dfn>s for 'macro' have the same linking text '13 january 2024'.
LINE ~4124: No 'dfn' refs found for '[date]'.
[=[DATE]=]
 ✔  Successfully generated, but fatal errors were suppressed
```