### PR TITLE
Fix macro references in Bikeshed documentation

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1187,7 +1187,7 @@ There are several additional optional keys:
 	* <dfn>Canonical URL</dfn> defines the canonical URL (as used by search engines) for the document; it can be set to "TR" (the default value if TR is defined), "ED", or a specific URL.
 	* <dfn>Favicon</dfn> defines the favicon URL for the document; it only supports one single URL.
 	* <dfn>Logo</dfn> defines the logo url for the document; it only supports one single url.
-		This URL can be used via the `[LOGO]` text macro ([[#text-macros]]),
+		This URL can be used via the <code>\[LOGO]</code> text macro ([[#text-macros]]),
 		and is by default used by the `logo` boilerplate section ([[#bp-sections]]).
 	* <dfn>Former Editor</dfn> must contain a former editor's information, in the same format as <a>Editor</a>.
 	* <dfn>Warning</dfn> must contain either "Obsolete", "Not Ready", "New Version XXX", "Replaced by XXX", "Commit deadb33f http://example.com/url/to/deadb33f replaced by XXX", "Branch XXX http://example.com/url/to/XXX replaced by YYY", or "Custom", which triggers the appropriate warning message in the boilerplate.
@@ -1287,11 +1287,11 @@ There are several additional optional keys:
 		* `markup`, covering the <a>dfn autolinks</a> for HTML/etc elements and attributes (the `<{foo}>` shorthand)
 
 		Everything but `markdown` defaults to "on".
-	* <dfn>Text Macro</dfn> lets you specify custom text macros, like `[TITLE]` or `[DATE]`, letting you fill in different text when building a spec in multiple ways.  (This is mostly useful as a command-line option.)  Each <a>Text Macro</a> line consists of a macro name, which must be uppercase and alphanumeric, followed by the text it will get replaced with.
-	* <dfn>Work Status</dfn> indicates the status of the document, in a way unrelated to the publication status of <a for=metadata>Status</a>.  It must be one of (completed, stable, testing, refining, revising, exploring, rewriting, abandoned), with those terms defined in [Fantasai's blog](http://fantasai.inkedblade.net/weblog/2011/inside-csswg/process). This just sets the `[WORKSTATUS]` text macro to the corresponding word, used in some of the boilerplates to pipe the metadata to scraping tools.
+	* <dfn>Text Macro</dfn> lets you specify custom text macros, like <code>\[TITLE]</code> or <code>\[DATE]</code>, letting you fill in different text when building a spec in multiple ways.  (This is mostly useful as a command-line option.)  Each <a>Text Macro</a> line consists of a macro name, which must be uppercase and alphanumeric, followed by the text it will get replaced with.
+	* <dfn>Work Status</dfn> indicates the status of the document, in a way unrelated to the publication status of <a for=metadata>Status</a>.  It must be one of (completed, stable, testing, refining, revising, exploring, rewriting, abandoned), with those terms defined in [Fantasai's blog](http://fantasai.inkedblade.net/weblog/2011/inside-csswg/process). This just sets the <code>\[WORKSTATUS]</code> text macro to the corresponding word, used in some of the boilerplates to pipe the metadata to scraping tools.
 	* <dfn>Repository</dfn> indicates the repository the spec is being tracked in.
 		You can specify a url followed by a "short name" for it,
-		and it populates the `[REPOSITORY]` and `[REPOSITORYURL]` text macros accordingly.
+		and it populates the <code>\[REPOSITORY]</code> and <code>\[REPOSITORYURL]</code> text macros accordingly.
 		If you are using GitHub,
 		you can just specify `username/repo`,
 		and Bikeshed will infer the rest for you.
@@ -2186,9 +2186,9 @@ which are valid only inside the included file:
 	</pre>
 </xmp>
 
-With the above code, you can use `[FOO]` and `[BAZ]` macros inside the include file,
+With the above code, you can use <code>\[FOO]</code> and <code>\[BAZ]</code> macros inside the include file,
 and they'll be substituted with "bar" and "qux qux qux", respectively.
-(Remember that you can mark text macros as optional by appending a `?`, like `[FOO?]`,
+(Remember that you can mark text macros as optional by appending a `?`, like <code>\[FOO?]</code>,
 in which case they'll be replaced with the empty string if Bikeshed can't find a definition.)
 
 ### Including Code Files ### {#including-code}
@@ -2478,7 +2478,7 @@ There are additional types for WebIDL definitions:
 * iterator
 * maplike
 * setlike
-* extended-attribute (things like `[EnforceRange]`)
+* extended-attribute (things like <code>\[EnforceRange]</code>)
 
 And for HTML/SVG/etc element definitions:
 
@@ -4095,31 +4095,31 @@ Text Macros {#text-macros}
 -----------
 
 Several text "macros" are defined by the spec's metadata,
-and can be used anywhere in the spec to substitute in the spec they stand for by using the syntax `[FOO]`.
-Note that this is similar to the syntax for bibliography references, but it has only a single set of `[]` characters, and the text must be uppercase.
+and can be used anywhere in the spec to substitute in the spec they stand for by using the syntax <code>\[FOO]</code>.
+Note that this is similar to the syntax for bibliography references, but it has only a single set of <code>[]</code> characters, and the text must be uppercase.
 The following macros are defined:
 
 <ul dfn-type=dfn dfn-for=macro export>
-	* <dfn>`[TITLE]`</dfn> gives the spec's full title, as extracted from either the H1 or the spec metadata.
-	* <dfn>`[H1]`</dfn> gives the desired document heading, in case the in-page title is supposed to be different from the `<title>` element value.
-	* <dfn>`[SHORTNAME]`</dfn> gives the document's shortname, like "css-cascade".
-	* <dfn>`[VSHORTNAME]`</dfn> gives the "versioned" shortname, like "css-cascade-3".
-	* <dfn>`[STATUS]`</dfn> gives the spec's status.
-	* <dfn>`[LONGSTATUS]`</dfn> gives a long form of the spec's status, so "ED" becomes "Editor's Draft", for example.
-	* <dfn>`[STATUSTEXT]`</dfn> gives an additional status text snippet.
-	* <dfn>`[LATEST]`</dfn> gives the link to the undated /TR link, if it exists.
-	* <dfn>`[VERSION]`</dfn> gives the link to the ED, if the spec is an ED, and otherwise constructs a dated /TR link from today's date.
-	* <dfn>`[ABSTRACT]`</dfn> gives the document's abstract.
-	* <dfn>`[ABSTRACTATTR]`</dfn> gives the document's abstract, correctly escaped to be an attribute value.
-	* <dfn>`[YEAR]`</dfn> gives the current year.
-	* <dfn>`[DATE]`</dfn> or <dfn>`[DATE-DMMY]`</dfn> gives a human-readable date like "30 January 2000".
-	* <dfn>`[DATE-MY]`</dfn> gives a partial date like "Jan 2000"
-	* <dfn>`[DATE-MMY]`</dfn> gives a partial date like "January 2000"
-	* <dfn>`[CDATE]`</dfn> gives a compact date in the format "YYYYMMDD", like "20000130"
-	* <dfn>`[ISODATE]`</dfn> gives a compact date in iso format "YYYY-MM-DD", like "2000-01-30"
-	* <dfn>`[DEADLINE]`</dfn> gives a human-readable version of the deadline date (formatted like [=\[DATE]=]), if one was specified.
-	* <dfn>`[LOGO]`</dfn> gives the url of the spec's logo.
-	* <dfn>`[REPOSITORY]`</dfn> gives the name of the VCS repository the spec is located in;
+	* <dfn><code>\[TITLE]</code></dfn> gives the spec's full title, as extracted from either the H1 or the spec metadata.
+	* <dfn><code>\[H1]</code></dfn> gives the desired document heading, in case the in-page title is supposed to be different from the `<title>` element value.
+	* <dfn><code>\[SHORTNAME]</code></dfn> gives the document's shortname, like "css-cascade".
+	* <dfn><code>\[VSHORTNAME]</code></dfn> gives the "versioned" shortname, like "css-cascade-3".
+	* <dfn><code>\[STATUS]</code></dfn> gives the spec's status.
+	* <dfn><code>\[LONGSTATUS]</code></dfn> gives a long form of the spec's status, so "ED" becomes "Editor's Draft", for example.
+	* <dfn><code>\[STATUSTEXT]</code></dfn> gives an additional status text snippet.
+	* <dfn><code>\[LATEST]</code></dfn> gives the link to the undated /TR link, if it exists.
+	* <dfn><code>\[VERSION]</code></dfn> gives the link to the ED, if the spec is an ED, and otherwise constructs a dated /TR link from today's date.
+	* <dfn><code>\[ABSTRACT]</code></dfn> gives the document's abstract.
+	* <dfn><code>\[ABSTRACTATTR]</code></dfn> gives the document's abstract, correctly escaped to be an attribute value.
+	* <dfn><code>\[YEAR]</code></dfn> gives the current year.
+	* <dfn><code>\[DATE]</code></dfn> or <dfn><code>\[DATE-DMMY]</code></dfn> gives a human-readable date like "30 January 2000".
+	* <dfn><code>\[DATE-MY]</code></dfn> gives a partial date like "Jan 2000"
+	* <dfn><code>\[DATE-MMY]</code></dfn> gives a partial date like "January 2000"
+	* <dfn><code>\[CDATE]</code></dfn> gives a compact date in the format "YYYYMMDD", like "20000130"
+	* <dfn><code>\[ISODATE]</code></dfn> gives a compact date in iso format "YYYY-MM-DD", like "2000-01-30"
+	* <dfn><code>\[DEADLINE]</code></dfn> gives a human-readable version of the deadline date (formatted like [=\[DATE]=]), if one was specified.
+	* <dfn><code>\[LOGO]</code></dfn> gives the url of the spec's logo.
+	* <dfn><code>\[REPOSITORY]</code></dfn> gives the name of the VCS repository the spec is located in;
 		this is currently only filled when the spec source is in a GitHub repository.
 		(Patches welcome for more repo-extraction code!)
 </ul>
@@ -4127,7 +4127,7 @@ The following macros are defined:
 As these are substituted at the text level, not the higher HTML level, you can use them *anywhere*, including in attribute values.
 
 You can mark a macro as "optional" by appending a `?` to its name,
-like `[DATE?]`.
+like <code>\[DATE?]</code>.
 This will cause Bikeshed to just remove it
 (replace it with the empty string)
 if it can't find a definition,
@@ -4173,7 +4173,7 @@ Inclusion conditions can be:
 	If you're conditioning an element on the existence of a text macro
 	so you can use that macro only when it is defined,
 	make sure the text macro is marked as *optional* when you use it
-	(written as `[FOO?]` rather than just `[FOO]`),
+	(written as <code>\[FOO?]</code> rather than just <code>\[FOO]</code>),
 	so it doesn't trigger an "unknown text macro" error
 	before throwing away the element anyway.
 
@@ -4374,9 +4374,9 @@ Here is a basic example `header.include` file:
 
 This uses several of Bikeshed's boilerplating features:
 
-* Text replacement, via the `[FOO]` macros.
+* Text replacement, via the <code>\[FOO]</code> macros.
 	These macros are prepopulated by Bikeshed,
-	either from metadata in the spec (like `[TITLE]`) or from environment data (like `[DATE]`).
+	either from metadata in the spec (like <code>\[TITLE]</code>) or from environment data (like <code>\[DATE]</code>).
 	The full list of text macros can be found at [[#text-macros]].
 
 * Boilerplate pieces, via empty container elements with `data-fill-with` attributes.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1488,9 +1488,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 815accb43, updated Thu Dec 21 14:10:37 2023 -0800" name="generator">
+  <meta content="Bikeshed version c20becf03, updated 2024-01-24 12:30:35 -0800" name="generator">
   <link href="https://speced.github.io/bikeshed/" rel="canonical">
-  <meta content="815accb43c1370ab476546acca5e80f08024a1f8" name="revision">
+  <meta content="c20becf03fd776947976073d499f478a613359eb" name="revision">
 <style>/* Boilerplate: style-autolinks */
 .css.css, .property.property, .descriptor.descriptor {
     color: var(--a-normal-text);
@@ -2298,7 +2298,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Bikeshed Documentation</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Living Standard, <time class="dt-updated" datetime="2023-12-21">21 December 2023</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Living Standard, <time class="dt-updated" datetime="2024-01-25">25 January 2024</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2313,7 +2313,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" height="15" src="https://licensebuttons.net/p/zero/1.0/80x15.png" width="80"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 21 December 2023,
+In addition, as of 25 January 2024,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -8151,20 +8151,33 @@ function getRootLevelAbsolutePosition(el) {
     };
 }
 
-document.addEventListener("DOMContentLoaded", () => {
-    document.body.addEventListener("mouseover", e=>{
-        let link = e.target.closest("a");
-        if(link) showRefHint(link);
-    });
-    document.body.addEventListener("focus", e=>{
-        let link = e.target.closest("a");
-        if(link) showRefHint(link);
-    });
+function showRefHintListener(e) {
+    // If the target isn't in a link (or is a link),
+    // just ignore it.
+    let link = e.target.closest("a");
+    if(!link) return;
 
-    document.body.addEventListener("click", (e) => {
-        // If not handled already, just hide all link panels.
-        hideAllRefHints();
-    });
+    // If the target is in a ref-hint panel
+    // (aka a link in the already-open one),
+    // also just ignore it.
+    if(link.closest(".ref-hint")) return;
+
+    // Otherwise, show the panel for the link.
+    showRefHint(link);
+}
+
+function hideAllHintsListener(e) {
+    // If the click is inside a ref-hint panel, ignore it.
+    if(e.target.closest(".ref-hint")) return;
+    // Otherwise, close all the current panels.
+    hideAllRefHints();
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    document.body.addEventListener("mouseover", showRefHintListener);
+    document.body.addEventListener("focus", showRefHintListener);
+
+    document.body.addEventListener("click", hideAllHintsListener);
 });
 
 window.addEventListener("resize", () => {


### PR DESCRIPTION
Since 16c53d7 the syntax <code>\`[MACRO]\`</code> is no longer protected from replacement, and an escaped <code>\`\\[MACRO]\`</code> reference will be output as `<code>\[MACRO]</code>`.
So, replace all <code>\`[MACRO]\`</code> references with `<code>\[MACRO]</code>` in the bikeshed documentation source, which is correctly translated into the output document as `<code>[MACRO]</code>`.

The regenerated `docs/index.html` (included) differs only by code changes made to bikeshed's HTML generation boilerplate since the last time it was generated.

Affects #2765 (specifically, the `docs/index.html` generated there)