### PR TITLE
Adding Alliance for Open Media specification statuses

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1154,6 +1154,14 @@ Several keys are required information, and will cause the processor to flag an e
 			* STAGE3
 			* STAGE4
 		</details>
+		<details>
+			<summary>Statuses usable by the AOM groups</summary>
+
+			* PD: "Pre-Draft"
+			* WGD: "Working Group Draft"
+			* WGA: "Working Group Approved Draft"
+			* FD: "Final Deliverable"
+		</details>
 
 	* <dfn>ED</dfn> (or its synonym <dfn>URL</dfn>) must contain a link that points to the most current draft
 		(typically the "editor's draft", or otherwise the version that's most live and updated).


### PR DESCRIPTION
The [Alliance for Open Media](https://aomedia.org) is using bikeshed in several specifications and these are the statuses we defined.