### PR TITLE
Pick some dark `<var>` colors

### DIFF
--- a/bikeshed/stylescript/var-click-highlighting.css
+++ b/bikeshed/stylescript/var-click-highlighting.css
@@ -17,3 +17,12 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}

--- a/tests/algorithm001.html
+++ b/tests/algorithm001.html
@@ -547,6 +547,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/app-history/spec.html
+++ b/tests/github/WICG/app-history/spec.html
@@ -770,6 +770,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/background-fetch/index.html
+++ b/tests/github/WICG/background-fetch/index.html
@@ -989,6 +989,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/background-sync/spec/PeriodicBackgroundSync-index.html
+++ b/tests/github/WICG/background-sync/spec/PeriodicBackgroundSync-index.html
@@ -932,6 +932,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/contact-api/spec/index.html
+++ b/tests/github/WICG/contact-api/spec/index.html
@@ -708,6 +708,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/content-index/spec/index.html
+++ b/tests/github/WICG/content-index/spec/index.html
@@ -950,6 +950,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/conversion-measurement-api/index.html
+++ b/tests/github/WICG/conversion-measurement-api/index.html
@@ -708,6 +708,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/cookie-store/index.html
+++ b/tests/github/WICG/cookie-store/index.html
@@ -727,6 +727,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/document-policy/index.html
+++ b/tests/github/WICG/document-policy/index.html
@@ -582,6 +582,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/element-timing/index.html
+++ b/tests/github/WICG/element-timing/index.html
@@ -932,6 +932,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/entries-api/index.html
+++ b/tests/github/WICG/entries-api/index.html
@@ -933,6 +933,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/event-timing/index.html
+++ b/tests/github/WICG/event-timing/index.html
@@ -932,6 +932,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/file-system-access/index.html
+++ b/tests/github/WICG/file-system-access/index.html
@@ -951,6 +951,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/get-installed-related-apps/spec/index.html
+++ b/tests/github/WICG/get-installed-related-apps/spec/index.html
@@ -708,6 +708,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/idle-detection/index.html
+++ b/tests/github/WICG/idle-detection/index.html
@@ -945,6 +945,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
 <style>/* Boilerplate: style-wpt */
 :root {

--- a/tests/github/WICG/import-maps/spec.html
+++ b/tests/github/WICG/import-maps/spec.html
@@ -718,6 +718,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/keyboard-lock/index.html
+++ b/tests/github/WICG/keyboard-lock/index.html
@@ -710,6 +710,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/keyboard-map/index.html
+++ b/tests/github/WICG/keyboard-map/index.html
@@ -932,6 +932,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/kv-storage/spec.html
+++ b/tests/github/WICG/kv-storage/spec.html
@@ -753,6 +753,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/largest-contentful-paint/index.html
+++ b/tests/github/WICG/largest-contentful-paint/index.html
@@ -932,6 +932,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/layout-instability/index.html
+++ b/tests/github/WICG/layout-instability/index.html
@@ -932,6 +932,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/local-font-access/index.html
+++ b/tests/github/WICG/local-font-access/index.html
@@ -730,6 +730,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/page-lifecycle/spec.html
+++ b/tests/github/WICG/page-lifecycle/spec.html
@@ -708,6 +708,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/periodic-background-sync/index.html
+++ b/tests/github/WICG/periodic-background-sync/index.html
@@ -932,6 +932,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/portals/index.html
+++ b/tests/github/WICG/portals/index.html
@@ -932,6 +932,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
 <style>/* Boilerplate: style-wpt */
 :root {

--- a/tests/github/WICG/sanitizer-api/index.html
+++ b/tests/github/WICG/sanitizer-api/index.html
@@ -708,6 +708,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/scroll-to-text-fragment/index.html
+++ b/tests/github/WICG/scroll-to-text-fragment/index.html
@@ -708,6 +708,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
 <style>/* Boilerplate: style-wpt */
 :root {

--- a/tests/github/WICG/ua-client-hints/index.html
+++ b/tests/github/WICG/ua-client-hints/index.html
@@ -932,6 +932,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/video-rvfc/index.html
+++ b/tests/github/WICG/video-rvfc/index.html
@@ -708,6 +708,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/web-locks/index.html
+++ b/tests/github/WICG/web-locks/index.html
@@ -951,6 +951,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WICG/webpackage/loading.html
+++ b/tests/github/WICG/webpackage/loading.html
@@ -703,6 +703,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WebAudio/web-audio-api/index.html
+++ b/tests/github/WebAudio/web-audio-api/index.html
@@ -1108,6 +1108,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WebBluetoothCG/web-bluetooth/index.html
+++ b/tests/github/WebBluetoothCG/web-bluetooth/index.html
@@ -982,6 +982,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/WebBluetoothCG/web-bluetooth/scanning.html
+++ b/tests/github/WebBluetoothCG/web-bluetooth/scanning.html
@@ -715,6 +715,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/heycam/webidl/index.html
+++ b/tests/github/heycam/webidl/index.html
@@ -857,6 +857,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/immersive-web/anchors/index.html
+++ b/tests/github/immersive-web/anchors/index.html
@@ -762,6 +762,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/immersive-web/depth-sensing/index.html
+++ b/tests/github/immersive-web/depth-sensing/index.html
@@ -762,6 +762,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/immersive-web/hit-test/index.html
+++ b/tests/github/immersive-web/hit-test/index.html
@@ -988,6 +988,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/immersive-web/layers/webxrlayers-1.html
+++ b/tests/github/immersive-web/layers/webxrlayers-1.html
@@ -766,6 +766,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/immersive-web/lighting-estimation/index.html
+++ b/tests/github/immersive-web/lighting-estimation/index.html
@@ -765,6 +765,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/immersive-web/real-world-geometry/plane-detection.html
+++ b/tests/github/immersive-web/real-world-geometry/plane-detection.html
@@ -762,6 +762,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/immersive-web/webxr-hand-input/index.html
+++ b/tests/github/immersive-web/webxr-hand-input/index.html
@@ -990,6 +990,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/immersive-web/webxr-test-api/index.html
+++ b/tests/github/immersive-web/webxr-test-api/index.html
@@ -766,6 +766,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/immersive-web/webxr/index.html
+++ b/tests/github/immersive-web/webxr/index.html
@@ -995,6 +995,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/privacycg/private-click-measurement/private-click-measurement.html
+++ b/tests/github/privacycg/private-click-measurement/private-click-measurement.html
@@ -708,6 +708,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body>
   <header>

--- a/tests/github/w3c/FileAPI/index.html
+++ b/tests/github/w3c/FileAPI/index.html
@@ -931,6 +931,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">

--- a/tests/github/w3c/IndexedDB/index.html
+++ b/tests/github/w3c/IndexedDB/index.html
@@ -973,6 +973,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/ServiceWorker/docs/index.html
+++ b/tests/github/w3c/ServiceWorker/docs/index.html
@@ -934,6 +934,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/ServiceWorker/docs/v1/index.html
+++ b/tests/github/w3c/ServiceWorker/docs/v1/index.html
@@ -934,6 +934,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/ServiceWorker/publish/service_worker/WD-service-workers-20160830/index.html
+++ b/tests/github/w3c/ServiceWorker/publish/service_worker/WD-service-workers-20160830/index.html
@@ -710,6 +710,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/ServiceWorker/publish/service_worker_1/WD-service-workers-1-20161011/index.html
+++ b/tests/github/w3c/ServiceWorker/publish/service_worker_1/WD-service-workers-1-20161011/index.html
@@ -710,6 +710,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/accelerometer/index.html
+++ b/tests/github/w3c/accelerometer/index.html
@@ -710,6 +710,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/ambient-light/index.html
+++ b/tests/github/w3c/ambient-light/index.html
@@ -710,6 +710,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/clipboard-apis/index.html
+++ b/tests/github/w3c/clipboard-apis/index.html
@@ -934,6 +934,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/css-houdini-drafts/css-animation-worklet-1/Overview.html
+++ b/tests/github/w3c/css-houdini-drafts/css-animation-worklet-1/Overview.html
@@ -710,6 +710,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/css-houdini-drafts/css-layout-api/Overview.html
+++ b/tests/github/w3c/css-houdini-drafts/css-layout-api/Overview.html
@@ -724,6 +724,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/css-houdini-drafts/css-paint-api/Overview.html
+++ b/tests/github/w3c/css-houdini-drafts/css-paint-api/Overview.html
@@ -948,6 +948,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/css-houdini-drafts/css-properties-values-api/Overview.html
+++ b/tests/github/w3c/css-houdini-drafts/css-properties-values-api/Overview.html
@@ -934,6 +934,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/css-houdini-drafts/css-typed-om/Overview.html
+++ b/tests/github/w3c/css-houdini-drafts/css-typed-om/Overview.html
@@ -951,6 +951,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/csswg-drafts/css-conditional-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-conditional-3/Overview.html
@@ -935,6 +935,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
 <style>/* Boilerplate: style-wpt */
 :root {

--- a/tests/github/w3c/csswg-drafts/css-highlight-api-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-highlight-api-1/Overview.html
@@ -719,6 +719,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
 <style>/* Boilerplate: style-wpt */
 :root {

--- a/tests/github/w3c/csswg-drafts/css-images-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-images-3/Overview.html
@@ -1116,6 +1116,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
 <style>/* Boilerplate: style-wpt */
 :root {

--- a/tests/github/w3c/csswg-drafts/css-images-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-images-4/Overview.html
@@ -1160,6 +1160,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
 <style>/* Boilerplate: style-wpt */
 :root {

--- a/tests/github/w3c/csswg-drafts/css-lists-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-lists-3/Overview.html
@@ -940,6 +940,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
 <style>/* Boilerplate: style-wpt */
 :root {

--- a/tests/github/w3c/csswg-drafts/css-nav-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-nav-1/Overview.html
@@ -755,6 +755,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
 <style>/* Boilerplate: style-wpt */
 :root {

--- a/tests/github/w3c/csswg-drafts/css-pseudo-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-pseudo-4/Overview.html
@@ -935,6 +935,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
 <style>/* Boilerplate: style-wpt */
 :root {

--- a/tests/github/w3c/csswg-drafts/css-scoping-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-scoping-1/Overview.html
@@ -930,6 +930,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
 <style>/* Boilerplate: style-wpt */
 :root {

--- a/tests/github/w3c/csswg-drafts/css-scroll-anchoring-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-scroll-anchoring-1/Overview.html
@@ -809,6 +809,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
 <style>/* Boilerplate: style-wpt */
 :root {

--- a/tests/github/w3c/csswg-drafts/css-shadow-parts-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-shadow-parts-1/Overview.html
@@ -935,6 +935,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
 <style>/* Boilerplate: style-wpt */
 :root {

--- a/tests/github/w3c/csswg-drafts/css-syntax-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-syntax-3/Overview.html
@@ -632,6 +632,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
 <style>/* Boilerplate: style-wpt */
 :root {

--- a/tests/github/w3c/csswg-drafts/css-transforms-2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-transforms-2/Overview.html
@@ -930,6 +930,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
 <style>/* Boilerplate: style-wpt */
 :root {

--- a/tests/github/w3c/csswg-drafts/css-values-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-values-4/Overview.html
@@ -939,6 +939,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
 <style>/* Boilerplate: style-wpt */
 :root {

--- a/tests/github/w3c/csswg-drafts/selectors-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/selectors-4/Overview.html
@@ -935,6 +935,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
 <style>/* Boilerplate: style-wpt */
 :root {

--- a/tests/github/w3c/csswg-drafts/web-animations-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/web-animations-1/Overview.html
@@ -785,6 +785,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
 <style>/* Boilerplate: style-wpt */
 :root {

--- a/tests/github/w3c/fxtf-drafts/fill-stroke/Overview.html
+++ b/tests/github/w3c/fxtf-drafts/fill-stroke/Overview.html
@@ -833,6 +833,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/fxtf-drafts/geometry/Overview.html
+++ b/tests/github/w3c/fxtf-drafts/geometry/Overview.html
@@ -1134,6 +1134,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/geolocation-sensor/index.html
+++ b/tests/github/w3c/geolocation-sensor/index.html
@@ -710,6 +710,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/gyroscope/index.html
+++ b/tests/github/w3c/gyroscope/index.html
@@ -710,6 +710,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/longtasks/index.html
+++ b/tests/github/w3c/longtasks/index.html
@@ -939,6 +939,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/magnetometer/index.html
+++ b/tests/github/w3c/magnetometer/index.html
@@ -710,6 +710,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/mediacapture-record/MediaRecorder.html
+++ b/tests/github/w3c/mediacapture-record/MediaRecorder.html
@@ -727,6 +727,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/orientation-sensor/index.html
+++ b/tests/github/w3c/orientation-sensor/index.html
@@ -710,6 +710,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/orientation-sensor/releases/FPWD.html
+++ b/tests/github/w3c/orientation-sensor/releases/FPWD.html
@@ -710,6 +710,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/paint-timing/painttiming.html
+++ b/tests/github/w3c/paint-timing/painttiming.html
@@ -934,6 +934,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/permissions/index.html
+++ b/tests/github/w3c/permissions/index.html
@@ -934,6 +934,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/proximity/index.html
+++ b/tests/github/w3c/proximity/index.html
@@ -710,6 +710,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/reporting/network-reporting.html
+++ b/tests/github/w3c/reporting/network-reporting.html
@@ -584,6 +584,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/sensors/index.html
+++ b/tests/github/w3c/sensors/index.html
@@ -732,6 +732,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/webappsec-credential-management/index.html
+++ b/tests/github/w3c/webappsec-credential-management/index.html
@@ -934,6 +934,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/webappsec-csp/index.html
+++ b/tests/github/w3c/webappsec-csp/index.html
@@ -743,6 +743,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/webappsec-fetch-metadata/index.html
+++ b/tests/github/w3c/webappsec-fetch-metadata/index.html
@@ -808,6 +808,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/webappsec-permissions-policy/index.html
+++ b/tests/github/w3c/webappsec-permissions-policy/index.html
@@ -950,6 +950,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/webdriver-bidi/index.html
+++ b/tests/github/w3c/webdriver-bidi/index.html
@@ -584,6 +584,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/webtransport/index.html
+++ b/tests/github/w3c/webtransport/index.html
@@ -710,6 +710,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/w3c/webvtt/index.html
+++ b/tests/github/w3c/webvtt/index.html
@@ -722,6 +722,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">

--- a/tests/github/whatwg/fullscreen/fullscreen.html
+++ b/tests/github/whatwg/fullscreen/fullscreen.html
@@ -79,6 +79,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry status-LS">
   <div class="head">

--- a/tests/github/whatwg/quirks/quirks.html
+++ b/tests/github/whatwg/quirks/quirks.html
@@ -81,6 +81,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry status-LS">
   <div class="head">

--- a/tests/github/whatwg/storage/storage.html
+++ b/tests/github/whatwg/storage/storage.html
@@ -79,6 +79,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry status-LS">
   <div class="head">

--- a/tests/github/whatwg/streams/index.html
+++ b/tests/github/whatwg/streams/index.html
@@ -82,6 +82,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry status-LS">
   <div class="head">

--- a/tests/var002.html
+++ b/tests/var002.html
@@ -423,6 +423,15 @@ var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEE
 var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
 var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+@media (prefers-color-scheme: dark) {
+  var[data-var-color="0"] { background-color: oklab(50%   0% 108%); box-shadow: 0 0 0 2px oklab(50%   0% 108%); }
+  var[data-var-color="1"] { background-color: oklab(50% 102%  38%); box-shadow: 0 0 0 2px oklab(50% 102%  38%); }
+  var[data-var-color="2"] { background-color: oklab(50% -51%  51%); box-shadow: 0 0 0 2px oklab(50% -51%  51%); }
+  var[data-var-color="3"] { background-color: oklab(50% -64% -20%); box-shadow: 0 0 0 2px oklab(50% -64% -20%); }
+  var[data-var-color="4"] { background-color: oklab(50%   6%  19%); box-shadow: 0 0 0 2px oklab(50%   6%  19%); }
+  var[data-var-color="5"] { background-color: oklab(50% -12% -64%); box-shadow: 0 0 0 2px oklab(50% -12% -64%); }
+  var[data-var-color="6"] { background-color: oklab(50%  44% -19%); box-shadow: 0 0 0 2px oklab(50%  44% -19%); }  
+}
 </style>
  <body class="h-entry">
   <div class="head">


### PR DESCRIPTION
It seems okay to use oklab now? The comment said the original
values had a and b go from [-128 to +128] so scaled them
to oklab which goes from [-100% to 100%]. Colors 2 and 3 seemed
too close to me so I adjusted color 3 slightly.

[Example](https://jsgist.org/?src=c0db656fdeb5dabe826d2a14860e3c18)

<img width="210" alt="Screenshot 2024-05-06 at 15 07 38" src="https://github.com/speced/bikeshed/assets/234804/aafe4260-8334-455b-b841-eec6fc246139">


#2157 