### PR TITLE
Add the htmlwg as a w3c group

### DIFF
--- a/bikeshed/config/status.py
+++ b/bikeshed/config/status.py
@@ -222,6 +222,7 @@ megaGroups = {
             "gpuwg",
             "houdini",
             "html",
+            "htmlwg",
             "httpslocal",
             "i18n",
             "immersivewebcg",


### PR DESCRIPTION
There's already html, but that corresponds to the old https://www.w3.org/groups/wg/html, which is distinct from https://www.w3.org/groups/wg/htmlwg/