### PR TITLE
use absolute import in __main__ to support direct use of pyinstaller

### DIFF
--- a/bikeshed/__main__.py
+++ b/bikeshed/__main__.py
@@ -1,3 +1,3 @@
-from .cli import main
+from bikeshed.cli import main
 
 main()


### PR DESCRIPTION
goal: allow users to create an exe/bundle/whatever bikeshed pip package directly using PyInstaller without undue difficulty.

problem: since the current `bikeshed/__main__.py` uses relative imports it's not directly usable with pyinstaller. you instead need to create your own wrapper package around bikeshed that calls into the bikeshed.cli.main() function yourself:

```sh
pip install bikeshed
```

```py
# mybikeshedhack/__main__.py
from bikeshed.cli import main

main()
```

```sh
pyinstaller -y --collect-all=bikeshed --name=bikeshed mybikeshedhack/__main__.py
```

why is this wrapper so painful? it's not. this is in reality a very tiny problem but since it's also a very tiny change I figured id open a pr. 🤷‍♀️

but it does 1) creating a venv 2) installing bikeshed as a dep (and managing it in like pyproject.toml or requirements.txt or whatever) and 3) remembering the incantation to start bikeshed.cli.main()

solution: use absolute imports in the `bikeshed/__main__.py` file so that you can do this without that extra wrapper.

```sh
pip install bikeshed # or pipx if you can find the venv
# then just use the raw __main__.py from bikeshed directly! no wrapper file!

pyinstaller -y --collect-all=bikeshed ...wherever_venv.../bikeshed/__main__.py

# OR dynamically
pyinstaller -y --collect-all=bikeshed "$(python -c "from importlib.util import find_spec; print(find_spec('bikeshed.__main__').origin)")"
```

