### PR TITLE
Update references to "IEEE 754" to the latest version.

### DIFF
--- a/bikeshed/spec-data/readonly/biblio/biblio-ie.data
+++ b/bikeshed/spec-data/readonly/biblio/biblio-ie.data
@@ -1,5 +1,16 @@
 d:ieee-754
 IEEE-754
+22 July 2019
+
+IEEE Standard for Floating-Point Arithmetic
+https://ieeexplore.ieee.org/document/8766229
+
+
+
+
+-
+d:ieee-754-2008
+IEEE-754-2008
 29 August 2008
 
 IEEE Standard for Floating-Point Arithmetic
@@ -22,6 +33,10 @@ http://ieeexplore.ieee.org/servlet/opac?punumber=2355
 -
 a:ieee-754-2008
 IEEE-754-2008
+IEEE-754
+-
+a:ieee-754-2019
+IEEE-754-2019
 IEEE-754
 -
 s:ieee1363

--- a/tests/github/heycam/webidl/index.html
+++ b/tests/github/heycam/webidl/index.html
@@ -14765,7 +14765,7 @@ language binding.</p>
    <dt id="biblio-html">[HTML]
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-ieee-754">[IEEE-754]
-   <dd><a href="http://ieeexplore.ieee.org/servlet/opac?punumber=4610933"><cite>IEEE Standard for Floating-Point Arithmetic</cite></a>. 29 August 2008. URL: <a href="http://ieeexplore.ieee.org/servlet/opac?punumber=4610933">http://ieeexplore.ieee.org/servlet/opac?punumber=4610933</a>
+   <dd><a href="https://ieeexplore.ieee.org/document/8766229"><cite>IEEE Standard for Floating-Point Arithmetic</cite></a>. 22 July 2019. URL: <a href="https://ieeexplore.ieee.org/document/8766229">https://ieeexplore.ieee.org/document/8766229</a>
    <dt id="biblio-infra">[INFRA]
    <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/"><cite>Infra Standard</cite></a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-perlre">[PERLRE]

--- a/tests/github/whatwg/streams/index.html
+++ b/tests/github/whatwg/streams/index.html
@@ -9126,7 +9126,7 @@ if ("serviceWorker" in navigator) {
    <dt id="biblio-html">[HTML]
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-ieee-754">[IEEE-754]
-   <dd><a href="http://ieeexplore.ieee.org/servlet/opac?punumber=4610933"><cite>IEEE Standard for Floating-Point Arithmetic</cite></a>. 29 August 2008. URL: <a href="http://ieeexplore.ieee.org/servlet/opac?punumber=4610933">http://ieeexplore.ieee.org/servlet/opac?punumber=4610933</a>
+   <dd><a href="https://ieeexplore.ieee.org/document/8766229"><cite>IEEE Standard for Floating-Point Arithmetic</cite></a>. 22 July 2019. URL: <a href="https://ieeexplore.ieee.org/document/8766229">https://ieeexplore.ieee.org/document/8766229</a>
    <dt id="biblio-infra">[INFRA]
    <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/"><cite>Infra Standard</cite></a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-webidl">[WEBIDL]


### PR DESCRIPTION
Add a reference for the current version of IEEE 754, which is "IEEE 754-2019", from the previous version which was "IEEE 754-2008".