### PR TITLE
Limit Findings and Draft Findings to the TAG.

### DIFF
--- a/bikeshed/spec-data/readonly/boilerplate/doctypes.kdl
+++ b/bikeshed/spec-data/readonly/boilerplate/doctypes.kdl
@@ -68,8 +68,6 @@ status "LS-COMMIT" "Commit Snapshot"
 status "LS-BRANCH" "Branch Snapshot"
 status "LS-PR" "PR Preview"
 status "LD" "Living Document"
-status "DRAFT-FINDING" "Draft Finding"
-status "FINDING" "Finding"
 
 org "whatwg" {
     group "whatwg" priv-sec=false
@@ -263,11 +261,11 @@ org "w3c" {
     }
     status "DRAFT-FINDING" "Draft Finding" {
         requires "ED"
-        group-types "wg" "tag"
+        group-types "tag"
     }
     status "FINDING" "Finding" {
         requires "TR"
-        group-types "wg" "tag"
+        group-types "tag"
     }
 }
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1067,7 +1067,6 @@ Several keys are required information, and will cause the processor to flag an e
 			* LS-COMMIT: "Commit Snapshot"
 			* LS-BRANCH: "Branch Snapshot"
 			* LD: "Living Document"
-			* FINDING: "Finding"
 		</details>
 		<details>
 			<summary>Statuses usable by W3C groups</summary>
@@ -1091,6 +1090,8 @@ Several keys are required information, and will cause the processor to flag an e
 			* UD: "Unofficial Proposal Draft"
 			* CG-DRAFT: "Draft Community Group Report"
 			* CG-FINAL: "Final Community Group Report"
+			* DRAFT-FINDING: "Draft Finding" (Only usable by the TAG)
+			* FINDING: "Finding" (Only usable by the TAG)
 
 			Bikeshed has a listing of what Groups are associated with the W3C.
 			If your Group isn't on that list,

--- a/tests/github/WICG/keyboard-lock/index.console.txt
+++ b/tests/github/WICG/keyboard-lock/index.console.txt
@@ -1,4 +1,4 @@
-WARNING: You used Status CG-DRAFT, but your Group (WEBPLATFORM) is limited to the statuses CR, CRD, CRY, CRYD, DRAFT-FINDING, DRY, ED, FINDING, FPWD, LCWD, LS, MO, NOTE, NOTE-ED, NOTE-FPWD, NOTE-WD, PER, PR, REC, RY, UD, WD, or WG-NOTE.
+WARNING: You used Status CG-DRAFT, but your Group (WEBPLATFORM) is limited to the statuses CR, CRD, CRY, CRYD, DRY, ED, FPWD, LCWD, LS, MO, NOTE, NOTE-ED, NOTE-FPWD, NOTE-WD, PER, PR, REC, RY, UD, WD, or WG-NOTE.
 LINT: Your document appears to use tabs to indent, but line 40 starts with spaces.
 LINT: Your document appears to use tabs to indent, but line 41 starts with spaces.
 LINT: Your document appears to use tabs to indent, but line 54 starts with spaces.

--- a/tests/github/jfbastien/papers/source/N4455.bs
+++ b/tests/github/jfbastien/papers/source/N4455.bs
@@ -1,7 +1,7 @@
 <pre class='metadata'>
 Title: No Sane Compiler Would Optimize Atomics
 Shortname: N4455
-Status: FINDING
+Status: P
 Group: WG21
 URL: http://wg21.link/n4455
 Editor: JF Bastien, Google, jfb@google.com

--- a/tests/github/jfbastien/papers/source/N4455.html
+++ b/tests/github/jfbastien/papers/source/N4455.html
@@ -2087,7 +2087,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">N4455RNone<br>No Sane Compiler Would Optimize Atomics</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Finding of the WG21, <time class="dt-updated" datetime="1970-01-01">1970-01-01</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Published Proposal, <time class="dt-updated" datetime="1970-01-01">1970-01-01</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:


### PR DESCRIPTION
Other W3C groups should use Notes, which are defined in the Process.
Non-W3C groups can use Dream or an appropriate status from their org.
