### PR TITLE
Have serve print a URL instead of just a port.

### DIFF
--- a/bikeshed/Spec.py
+++ b/bikeshed/Spec.py
@@ -435,7 +435,7 @@ class Spec:
             socketserver.TCPServer.allow_reuse_address = True
             server = socketserver.TCPServer(("localhost" if localhost else "", port), SilentServer)
 
-            print(f"Serving at port {port}")  # noqa: T201
+            print(f"Serving at http://localhost:{port}/")  # noqa: T201
             thread = threading.Thread(target=server.serve_forever)
             thread.daemon = True
             thread.start()


### PR DESCRIPTION
This lets users click on the message in many terminal programs.
