### PR TITLE
Fix Candidate Recommendation Draft metadata checks

### DIFF
--- a/bikeshed/spec-data/readonly/boilerplate/doctypes.kdl
+++ b/bikeshed/spec-data/readonly/boilerplate/doctypes.kdl
@@ -188,7 +188,7 @@ org "w3c" {
         group-types "wg"
     }
     status "CRD" "W3C Candidate Recommendation Draft" {
-        requires "Level" "ED" "TR" "Issue Tracking" "Date" "Implementation Report" "Deadline"
+        requires "Level" "ED" "TR" "Issue Tracking" "Date" "Implementation Report"
         group-types "wg"
     }
     status "PR" "W3C Proposed Recommendation" {


### PR DESCRIPTION
CRD does not require this deadline information per process: https://www.w3.org/policies/process/#publishing-crud

Without this fix CRD builds without "Deadline" metadata will fail.

Fix #3031