### PR TITLE
fix solidcg copyright includes

### DIFF
--- a/bikeshed/spec-data/readonly/boilerplate/solidcg/copyright-CG-DRAFT.include
+++ b/bikeshed/spec-data/readonly/boilerplate/solidcg/copyright-CG-DRAFT.include
@@ -1,6 +1,4 @@
-<p>
-  Copyright © [YEAR] the Contributors to the [TITLE],
-  published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a>
-  under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
-  A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.
-</p>
+Copyright © [YEAR] the Contributors to the [TITLE],
+published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a>
+under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.

--- a/bikeshed/spec-data/readonly/boilerplate/solidcg/copyright-CG-FINAL.include
+++ b/bikeshed/spec-data/readonly/boilerplate/solidcg/copyright-CG-FINAL.include
@@ -1,6 +1,4 @@
-<p>
-  Copyright © [YEAR] the Contributors to the [TITLE],
-  published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a>
-  under the <a href="https://www.w3.org/community/about/agreements/final/">W3C Community Final Specification Agreement (FSA)</a>.
-  A human-readable <a href="https://www.w3.org/community/about/agreements/fsa-deed/">summary</a> is available.
-</p>
+Copyright © [YEAR] the Contributors to the [TITLE],
+published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a>
+under the <a href="https://www.w3.org/community/about/agreements/final/">W3C Community Final Specification Agreement (FSA)</a>.
+A human-readable <a href="https://www.w3.org/community/about/agreements/fsa-deed/">summary</a> is available.


### PR DESCRIPTION
We are switching to spec-prod and Nu HTML check didn't pass due to nested `<p>` tags.