### PR TITLE
Remove redundant whitespace collapsing in link texts

### DIFF
--- a/bikeshed/refs/manager.py
+++ b/bikeshed/refs/manager.py
@@ -289,7 +289,6 @@ class ReferenceManager:
                 linkTexts = e.allTexts
             for linkText in linkTexts:
                 linkText = h.unfixTypography(linkText)
-                linkText = re.sub(r"\s+", " ", linkText)
                 linkType = h.treeAttr(el, "data-dfn-type")
                 if linkType not in config.dfnTypes:
                     m.die(f"Unknown local dfn type '{linkType}':\n  {h.outerHTML(el)}", el=el)


### PR DESCRIPTION
This is already done in linkTextsFromElement():
https://github.com/speced/bikeshed/blob/e80aec7a644d2034b5288466b8e365f6f6a7003f/bikeshed/h/dom.py#L200

It's only if unfixTypography() could introduce new runs of more than one space that this step would be needed, but that doesn't seem to be the case.