### PR TITLE
fix grid-auto-flow value in line-highlighting.css

### DIFF
--- a/bikeshed/highlight/line-highlighting.css
+++ b/bikeshed/highlight/line-highlighting.css
@@ -4,7 +4,7 @@
 .line-numbered {
     display: grid !important;
     grid-template-columns: min-content 1fr;
-    grid-auto-flow: rows;
+    grid-auto-flow: row;
 }
 .line-numbered > *,
 .line-numbered::before,


### PR DESCRIPTION
Fix grid-auto-flow value to "row" (instead of the incorrect "rows") in `line-highlighting.css`. 

This was causing HTML validation to fail when including line highlighting.