### PR TITLE
Support webref headings' alternateIds field.

### DIFF
--- a/bikeshed/spec-data/readonly/headings/headings-css-flexbox-1.json
+++ b/bikeshed/spec-data/readonly/headings/headings-css-flexbox-1.json
@@ -475,6 +475,20 @@
       "url": "https://www.w3.org/TR/css-flexbox-1/#conformance"
     }
   },
+  "#contents": {
+    "current": {
+      "number": "",
+      "spec": "CSS Flexbox 1",
+      "text": "Table of Contents",
+      "url": "https://drafts.csswg.org/css-flexbox-1/#toc"
+    },
+    "snapshot": {
+      "number": "",
+      "spec": "CSS Flexbox 1",
+      "text": "Table of Contents",
+      "url": "https://www.w3.org/TR/css-flexbox-1/#toc"
+    }
+  },
   "#cr-exit-criteria": {
     "snapshot": {
       "number": "",
@@ -841,6 +855,30 @@
       "url": "https://www.w3.org/TR/css-flexbox-1/#intrinsic-main-sizes"
     }
   },
+  "#intrinsic-main-sizes-compat": {
+    "current": {
+      "number": "9.9.1.2",
+      "spec": "CSS Flexbox 1",
+      "text": "Web-compatible Intrinsic Sizing Algorithm",
+      "url": "https://drafts.csswg.org/css-flexbox-1/#intrinsic-main-sizes-compat"
+    }
+  },
+  "#intrinsic-main-sizes-ideal": {
+    "current": {
+      "number": "9.9.1.1",
+      "spec": "CSS Flexbox 1",
+      "text": "Ideal Algorithm",
+      "url": "https://drafts.csswg.org/css-flexbox-1/#intrinsic-main-sizes-ideal"
+    }
+  },
+  "#intrinsic-main-sizes-multiline": {
+    "current": {
+      "number": "9.9.1.3",
+      "spec": "CSS Flexbox 1",
+      "text": "Multi-line Min-content Algorithm",
+      "url": "https://drafts.csswg.org/css-flexbox-1/#intrinsic-main-sizes-multiline"
+    }
+  },
   "#intrinsic-sizes": {
     "current": {
       "number": "9.9",
@@ -867,6 +905,14 @@
       "spec": "CSS Flexbox 1",
       "text": "Introduction",
       "url": "https://www.w3.org/TR/css-flexbox-1/#intro"
+    }
+  },
+  "#issues-index": {
+    "current": {
+      "number": "",
+      "spec": "CSS Flexbox 1",
+      "text": "Issues Index",
+      "url": "https://drafts.csswg.org/css-flexbox-1/#issues-index"
     }
   },
   "#item-margins": {

--- a/bikeshed/update/updateCrossRefs.py
+++ b/bikeshed/update/updateCrossRefs.py
@@ -30,6 +30,7 @@ if t.TYPE_CHECKING:
         title: t.Required[str]
         level: t.Required[int]
         number: str
+        alternateIds: list[str]
 
     class HeadingT(t.TypedDict):
         url: str
@@ -345,15 +346,26 @@ def addToHeadings(
             page = "/" + page
             fragment = "#"
         shorthand = page + fragment
-    if shorthand not in specHeadings:
-        specHeadings[shorthand] = {}
-    headingGroup = t.cast("HeadingGroupT", specHeadings[shorthand])
-    headingGroup[status] = heading
-    if fragment not in specHeadings:
-        specHeadings[fragment] = []
-    keyList = t.cast("list[HeadingKeyT]", specHeadings[fragment])
-    if shorthand not in specHeadings[fragment]:
-        keyList.append(shorthand)
+
+    def addShorthandAndFragmentToSpecHeadings(shorthand: str, fragment: str) -> None:
+        if shorthand not in specHeadings:
+            specHeadings[shorthand] = {}
+        headingGroup = t.cast("HeadingGroupT", specHeadings[shorthand])
+        headingGroup[status] = heading
+        if fragment not in specHeadings:
+            specHeadings[fragment] = []
+        keyList = t.cast("list[HeadingKeyT]", specHeadings[fragment])
+        if shorthand not in specHeadings[fragment]:
+            keyList.append(shorthand)
+
+    addShorthandAndFragmentToSpecHeadings(shorthand, fragment)
+
+    # A heading may have multiple IDs: add the others as aliases of the primary one.
+    if "alternateIds" in rawAnchor:
+        shorthandBase, _, _ = shorthand.partition("#")
+        for alternateId in rawAnchor["alternateIds"]:
+            fragment = "#" + alternateId
+            addShorthandAndFragmentToSpecHeadings(shorthandBase + fragment, fragment)
 
 
 def cleanSpecHeadings(headings: AllHeadingsT) -> None:

--- a/tests/include003.html
+++ b/tests/include003.html
@@ -341,7 +341,7 @@ a[href].issue-return {
 .line-numbered {
     display: grid !important;
     grid-template-columns: min-content 1fr;
-    grid-auto-flow: rows;
+    grid-auto-flow: row;
 }
 .line-numbered > *,
 .line-numbered::before,

--- a/tests/pre003.html
+++ b/tests/pre003.html
@@ -341,7 +341,7 @@ a[href].issue-return {
 .line-numbered {
     display: grid !important;
     grid-template-columns: min-content 1fr;
-    grid-auto-flow: rows;
+    grid-auto-flow: row;
 }
 .line-numbered > *,
 .line-numbered::before,

--- a/tests/section-links003.bs
+++ b/tests/section-links003.bs
@@ -16,6 +16,11 @@ Specs Bikeshed Knows About {#a}
 
 [[css-flexbox-1#intro]]
 
+Specs with alternateIds {#aid}
+===============================
+
+[[css-flexbox-1#contents]]
+
 Specs SpecRef Knows About {#b}
 ==============================
 

--- a/tests/section-links003.console.txt
+++ b/tests/section-links003.console.txt
@@ -1,2 +1,2 @@
-LINE 22:1: Couldn't find section '#section-5.4' in spec 'rfc6265':
+LINE 27:1: Couldn't find section '#section-5.4' in spec 'rfc6265':
 [[RFC6265#section-5.4]]

--- a/tests/section-links003.html
+++ b/tests/section-links003.html
@@ -429,7 +429,8 @@ dfn > a.self-link::before      { content: "#"; }
    <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
    <ol class="toc" role="directory">
     <li><a href="#a"><span class="secno">1</span> <span class="content">Specs Bikeshed Knows About</span></a>
-    <li><a href="#b"><span class="secno">2</span> <span class="content">Specs SpecRef Knows About</span></a>
+    <li><a href="#aid"><span class="secno">2</span> <span class="content">Specs with alternateIds</span></a>
+    <li><a href="#b"><span class="secno">3</span> <span class="content">Specs SpecRef Knows About</span></a>
     <li>
      <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
      <ol class="toc">
@@ -440,7 +441,9 @@ dfn > a.self-link::before      { content: "#"; }
   <main>
    <h2 class="heading settled" data-level="1" id="a"><span class="secno">1. </span><span class="content">Specs Bikeshed Knows About</span><a class="self-link" href="#a"></a></h2>
    <p><a href="https://drafts.csswg.org/css-flexbox-1/#intro"><cite>CSS Flexbox 1</cite> § 1 Introduction</a></p>
-   <h2 class="heading settled" data-level="2" id="b"><span class="secno">2. </span><span class="content">Specs SpecRef Knows About</span><a class="self-link" href="#b"></a></h2>
+   <h2 class="heading settled" data-level="2" id="aid"><span class="secno">2. </span><span class="content">Specs with alternateIds</span><a class="self-link" href="#aid"></a></h2>
+   <p><a href="https://drafts.csswg.org/css-flexbox-1/#toc"><cite>CSS Flexbox 1</cite> §  Table of Contents</a></p>
+   <h2 class="heading settled" data-level="3" id="b"><span class="secno">3. </span><span class="content">Specs SpecRef Knows About</span><a class="self-link" href="#b"></a></h2>
    <p><span spec-section="#section-5.4"></span></p>
   </main>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>


### PR DESCRIPTION
I tested this by running `bikeshed update --skip-manifest --anchors` and copying the resulting file into spec-data/readonly.

Fixes #3107.