### PR TITLE
read and display data related to the CG spec transition plan if any

### DIFF
--- a/bikeshed/boilerplate.py
+++ b/bikeshed/boilerplate.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import dataclasses
+import json
 import os
 import re
 import subprocess
@@ -30,6 +31,18 @@ def loadBoilerplate(doc: t.SpecT, filename: str, bpname: str | None = None) -> N
         bpname = filename
     html = retrieve.retrieveBoilerplateFile(doc, filename)
     el = boilerplateFromHtml(doc, html, context=f"{filename} boilerplate")
+    if doc.md.cgTransitionPlan == True and filename == "status":
+        p = os.path.join(doc.inputSource.directory(), "cg-monitor.json")
+        with open(p, 'r') as f:
+            data = json.load(f)
+
+        html = "<div class=\"note\">"
+        html += "<p>Transition status: " + data["transition_status"] + "</p>"
+        html += "<p>Target organization ("+ data["intended_organization"] +") / group (" + data["intended_group"] + ")</p>"
+        for note in data["notes"]:
+            html += "<p>" + note + "</p>"
+        html += "</div>"
+        el.append(h.parseHTML(html))
     fillWith(bpname, el, doc=doc)
 
 

--- a/bikeshed/metadata.py
+++ b/bikeshed/metadata.py
@@ -66,6 +66,7 @@ class MetadataManager:
         self.boilerplate: config.BoolSet = config.BoolSet(default=True)
         self.canIUseURLs: list[str] = []
         self.canonicalURL: str | None = None
+        self.cgTransitionPlan: bool = False
         self.complainAbout: config.BoolSet = config.BoolSet(["mixed-indents"])
         self.customTextMacros: list[tuple[str, str]] = []
         self.customWarningText: list[str] = []
@@ -1395,6 +1396,7 @@ KNOWN_KEYS = {
     "Boilerplate": Metadata("Boilerplate", "boilerplate", joinBoolSet, parseBoilerplate),
     "Can I Use Url": Metadata("Can I Use URL", "canIUseURLs", joinList, parseLiteralList),
     "Canonical Url": Metadata("Canonical URL", "canonicalURL", joinValue, parseLiteral),
+    "Community Group Transition Plan": Metadata("CG Transition Plan", "cgTransitionPlan", joinValue, parseBoolean),
     "Complain About": Metadata("Complain About", "complainAbout", joinBoolSet, parseComplainAbout),
     "Custom Warning Text": Metadata(
         "Custom Warning Text",


### PR DESCRIPTION
The metadata file is expected to be located in the same directory as the spec itself and named `cg-monitor.json`.
Sample:
```json
{
  "transition_status": "Ready to transfer",
  "intended_implementations": [
    "Chrome",
    "Firefox",
    "Safari"
  ],
  "implementations": [
    "Chrome",
    "Firefox",
    "Safari"
  ],
  "intended_organization": "W3C",
  "intended_group": "webapps",
  "transition_plan": {
    "decision_to_migrate": null,
    "decision_to_receive": null,
    "ongoing_discussions": "https://github.com/w3c/webappswg/issues/118#issuecomment-2840981975"
  },
  "notes": [
    "The WebApps WG may add File and Directory Entries to the WD of File APIs after rechartering."
  ]
}
```