### PR TITLE
Document the <css> fake element.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3290,6 +3290,7 @@ It comes in three forms:
 	the contents are parsed as normal Bikeshed text,
 	and the whole thing is wrapped in `<span class=css>`,
 	which triggers a particular styling in W3C specs.
+	To get this styling explicitly, you can also write `<css>CSS text</css>`.
 
 
 Spec/Section Autolinks {#autolink-biblio}


### PR DESCRIPTION
This could also go next to https://speced.github.io/bikeshed/#id-assert which documents the other fake element, but this was a smaller change to get it mentioned at all.